### PR TITLE
Add snappy compression library

### DIFF
--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     tk \
     tk-dev \
     wget \
+    libsnappy-dev \
   && apt-get clean autoclean \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Needed for testing Parquet serialization in the `google-cloud-bigquery` library.