### PR TITLE
Upgrade pip and setuptools on java images

### DIFF
--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -68,6 +68,7 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 
 # Install python
 RUN pyenv install 3.6.1 && \
-    pyenv global 3.6.1
+    pyenv global 3.6.1 && \
+    python3 -m pip install --upgrade pip setuptools
 
 WORKDIR /workspace

--- a/java/java7/Dockerfile
+++ b/java/java7/Dockerfile
@@ -73,6 +73,7 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 
 # Install python
 RUN pyenv install 3.6.1 && \
-    pyenv global 3.6.1
+    pyenv global 3.6.1 && \
+    python3 -m pip install --upgrade pip setuptools
 
 WORKDIR /workspace

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -68,6 +68,7 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 
 # Install python
 RUN pyenv install 3.6.1 && \
-    pyenv global 3.6.1
+    pyenv global 3.6.1 && \
+    python3 -m pip install --upgrade pip setuptools
 
 WORKDIR /workspace


### PR DESCRIPTION
When trying to install a pip package like `gcp-docuploader`, you sometimes get `AttributeError: '_NamespacePath' object has no attribute 'sort'` which appears to be fixed by upgrading `pip` and `setuptools` [source](https://github.com/googleapis/google-cloud-python/issues/2990#issuecomment-283586901)