### PR TITLE
Pin java 7 to 1.7.0_151 which contains a fix for gradle

### DIFF
--- a/java/java7.yaml
+++ b/java/java7.yaml
@@ -17,7 +17,7 @@ commandTests:
 - name: "version"
   command: ["java", "-version"]
   # java -version outputs to stderr...
-  expectedError: ["(java|openjdk) version \"1.7.*\""]
+  expectedError: ["(java|openjdk) version \"1.7.0_151\""]
 - name: "maven"
   command: ["mvn", "-version"]
   expectedOutput: ["Apache Maven 3.5.*"]

--- a/java/java7/Dockerfile
+++ b/java/java7/Dockerfile
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:7-jdk
+FROM openjdk:7u151-jdk
+
+# Debian 8 base image has bad configuration for apt
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 
 RUN apt-get update && \
-    apt-get -y upgrade && \
+#     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends libxml2-utils && \
     rm -rf /var/cache/apt
 


### PR DESCRIPTION
See https://github.com/docker-library/openjdk/issues/117#issuecomment-355139057

The latest openjdk:7-jdk is broken