### PR TITLE
node: add graphviz to container image

### DIFF
--- a/node/10-user/Dockerfile
+++ b/node/10-user/Dockerfile
@@ -14,6 +14,14 @@
 
 FROM node:10-stretch
 
+# Add Graphviz
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    graphviz \
+    ; \
+  rm -rf /var/lib/apt/lists/*
+
 USER node
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash

--- a/node/11-user/Dockerfile
+++ b/node/11-user/Dockerfile
@@ -14,6 +14,14 @@
 
 FROM node:11-stretch
 
+# Add Graphviz
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    graphviz \
+    ; \
+  rm -rf /var/lib/apt/lists/*
+
 USER node
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash

--- a/node/12-user/Dockerfile
+++ b/node/12-user/Dockerfile
@@ -14,6 +14,14 @@
 
 FROM node:12-stretch
 
+# Add Graphviz
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    graphviz \
+    ; \
+  rm -rf /var/lib/apt/lists/*
+
 USER node
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash


### PR DESCRIPTION
This is a step toward https://github.com/GoogleCloudPlatform/nodejs-docs-samples/issues/1436.

An alternative to adding graphviz to the container is to pursue container-centric unit testing for Cloud Run on node.js as a follow-up to #16 