### PR TITLE
chore(ruby): Update runtime versions in Ruby images

### DIFF
--- a/ruby/autosynth/Dockerfile
+++ b/ruby/autosynth/Dockerfile
@@ -45,8 +45,8 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN rbenv install 2.5.3 && rbenv global 2.5.3 \
-    && gem install bundler --version 1.17.3 && gem install rake
+RUN rbenv install 2.6.5 && rbenv global 2.6.5 \
+    && gem install bundler:1.17.3 bundler:2.0.2 rake
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
@@ -60,8 +60,8 @@ RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc
 RUN echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.1
-RUN pyenv global 3.6.1
+RUN pyenv install 3.6.9
+RUN pyenv global 3.6.9
 
 # Install nodenv
 RUN git clone https://github.com/nodenv/nodenv.git ~/.nodenv
@@ -76,8 +76,8 @@ RUN mkdir -p "$(nodenv root)"/plugins
 RUN git clone https://github.com/nodenv/node-build.git "$(nodenv root)"/plugins/node-build
 
 # Install nodejs
-RUN nodenv install 10.13.0
-RUN nodenv global 10.13.0
+RUN nodenv install 10.16.3
+RUN nodenv global 10.16.3
 
 # Install docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -

--- a/ruby/ruby-multi/Dockerfile
+++ b/ruby/ruby-multi/Dockerfile
@@ -43,11 +43,11 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-ENV RUBY_VERSIONS "2.3.8 2.4.5 2.5.5 2.6.2"
+ENV RUBY_VERSIONS "2.4.9 2.5.7 2.6.5"
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN for version in ${RUBY_VERSIONS}; do \
         rbenv install "$version" && rbenv global "$version" && \
-        gem install bundler:1.17.3 && gem update --system \
+        gem install bundler:1.17.3 bundler:2.0.2 && gem update --system \
     ; done
 
 RUN apt-get -y autoremove && apt-get -y autoclean

--- a/ruby/ruby-release/Dockerfile
+++ b/ruby/ruby-release/Dockerfile
@@ -31,19 +31,19 @@ RUN apt-get -y autoclean
 # Install Ruby
 RUN mkdir $HOME/.ruby
 RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
-RUN $HOME/.ruby-build/bin/ruby-build 2.5.5 $HOME/.ruby
+RUN $HOME/.ruby-build/bin/ruby-build 2.6.5 $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN gem install bundler:1.17.3 && gem update --system
+RUN gem install bundler:1.17.3 bundler:2.0.2 rake && gem update --system
 
 # Install Python
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH /root/.pyenv/bin:$PATH
 ENV PATH /root/.pyenv/shims:$PATH
-RUN pyenv install 3.6.8
-RUN pyenv global 3.6.8
+RUN pyenv install 3.6.9
+RUN pyenv global 3.6.9
 RUN ln -s $(which python) /bin/python3
 
 RUN apt-get -y autoremove && apt-get -y autoclean


### PR DESCRIPTION
General update for runtimes and key libraries in the various Ruby images.
* Ruby -> 2.6.5
* Python 3.6.x -> 3.6.9
* Node -> 10.16.3
* Install both bundler 1.17.3 and 2.0.2 to support both gemfile formats
* In the image used to test libraries against multiple Ruby versions, remove the Ruby 2.3 because it is EOL, and update Ruby 2.4, 2.5, and 2.6 to the latest patch release of each.
