### PR TITLE
feat: add protoc to node Docker images

### DIFF
--- a/node/10-user/Dockerfile
+++ b/node/10-user/Dockerfile
@@ -22,6 +22,11 @@ RUN set -ex; \
     ; \
   rm -rf /var/lib/apt/lists/*
 
+# Setup protoc
+RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_64.zip > /tmp/protoc-3.10.1-linux-x86_64.zip && \
+    cd /usr/local && unzip /tmp/protoc-3.10.1-linux-x86_64.zip && rm -f /tmp/protoc-3.10.1-linux-x86_64.zip && \
+    chmod -R o+rX /usr/local/include/google /usr/local/bin/protoc
+
 USER node
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash

--- a/node/12-user/Dockerfile
+++ b/node/12-user/Dockerfile
@@ -22,6 +22,11 @@ RUN set -ex; \
     ; \
   rm -rf /var/lib/apt/lists/*
 
+# Setup protoc
+RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_64.zip > /tmp/protoc-3.10.1-linux-x86_64.zip && \
+    cd /usr/local && unzip /tmp/protoc-3.10.1-linux-x86_64.zip && rm -f /tmp/protoc-3.10.1-linux-x86_64.zip && \
+    chmod -R o+rX /usr/local/include/google /usr/local/bin/protoc
+
 USER node
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash

--- a/node/8-user/Dockerfile
+++ b/node/8-user/Dockerfile
@@ -14,6 +14,11 @@
 
 FROM node:8-stretch
 
+# Setup protoc
+RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_64.zip > /tmp/protoc-3.10.1-linux-x86_64.zip && \
+    cd /usr/local && unzip /tmp/protoc-3.10.1-linux-x86_64.zip && rm -f /tmp/protoc-3.10.1-linux-x86_64.zip && \
+    chmod -R o+rX /usr/local/include/google /usr/local/bin/protoc
+
 USER node
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash


### PR DESCRIPTION
We want to start using Kokoro for testing gapic-generator-typescript, and `protoc` is one of its dependencies. I can imagine that having it in the images won't hurt.

(I will appreciate your help with pushing the new images to gcr.io, I have no idea how to do it :) )