### PR TITLE
feat: Node 12 container for running puppeteer

### DIFF
--- a/node/12-puppeteer/Dockerfile
+++ b/node/12-puppeteer/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:12
+
+# Taken from
+# https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+
+# See https://crbug.com/795759
+RUN apt-get update && apt-get install -yq libgconf-2-4
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update && apt-get install -y wget --no-install-recommends \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge --auto-remove -y curl \
+    && rm -rf /src/*.deb
+
+# It's a good idea to use dumb-init to help prevent zombie chrome processes.
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+# Run everything after as non-privileged user.
+USER node
+
+ENTRYPOINT ["dumb-init", "--"]

--- a/node/cloudbuild.yaml
+++ b/node/cloudbuild.yaml
@@ -32,6 +32,12 @@ steps:
   dir: '8-puppeteer'
   waitFor: ['-']
 
+# Node 12-puppeteer
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:12-puppeteer', '.']
+  dir: '12-puppeteer'
+  waitFor: ['-']
+
 # Node 10
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:10-user', '.']


### PR DESCRIPTION
Allows us to use newer versions of Node.js in browser testing.