### PR TITLE
refactor(python): alphabetize package list

### DIFF
--- a/python/cloud-devrel-kokoro-resources/python/Dockerfile
+++ b/python/cloud-devrel-kokoro-resources/python/Dockerfile
@@ -17,22 +17,22 @@ FROM gcr.io/cloud-devrel-kokoro-resources/python-base:latest
 # Install libraries needed by third-party python packages that we depend on.
 RUN apt update \
   && apt install -y \
-    openssl \
+    graphviz \
+    libcurl4-openssl-dev \
     libffi-dev \
+    libjpeg-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libmysqlclient-dev \
+    libpng12-dev \
+    libpq-dev \
     libssl-dev \
     libxml2-dev \
     libxslt1-dev \
-    libpq-dev \
-    libmysqlclient-dev \
-    libcurl4-openssl-dev \
-    libjpeg-dev \
-    zlib1g-dev \
-    libpng12-dev \
-    python-pyaudio \
-    libmemcached-dev \
-    libmagickwand-dev \
+    openssl \
     portaudio19-dev \
-    graphviz \
+    python-pyaudio \
+    zlib1g-dev \
  && apt clean
 
 RUN python --version


### PR DESCRIPTION
This will make it easier to scan for existing packages and determine where to place addition packages in the future.

Aside: In order to build the protobuf docs, I considered adding the [protobuf-compiler package](https://packages.ubuntu.com/xenial/protobuf-compiler), but it's quite out-of-date in Ubuntu 16.04. I'll follow-up with a second image with C++ build tools available, instead.