### PR TITLE
chore: optimization debian package manager tweaks

### DIFF
--- a/go/go111/Dockerfile
+++ b/go/go111/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.11
 
 # Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip && which python3
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/go/go112/Dockerfile
+++ b/go/go112/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.12
 
 # Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip && which python3
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/go/go113/Dockerfile
+++ b/go/go113/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.13
 
 # Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip && which python3
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/go/go114/Dockerfile
+++ b/go/go114/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.14
 
 # Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip && which python3
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -54,7 +54,7 @@ RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install pyenv
-RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+RUN apt-get install -y --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python-openssl
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
@@ -73,7 +73,7 @@ RUN pyenv install 3.6.12 && \
 
 # Add Graphviz
 RUN apt-get update -y && \
-    apt-get install -y graphviz && \
+    apt-get install -y --no-install-recommends graphviz && \
     rm -rf /var/lib/apt/lists/*
     
 # Add imagemagick

--- a/java/java7/Dockerfile
+++ b/java/java7/Dockerfile
@@ -62,7 +62,7 @@ RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install pyenv
-RUN apt-get install -y --force-yes make build-essential libssl-dev zlib1g-dev libbz2-dev \
+RUN apt-get install -y --no-install-recommends --force-yes make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python-openssl
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -54,7 +54,7 @@ RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install pyenv
-RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+RUN apt-get install -y --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python-openssl
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv

--- a/node/10-user/Dockerfile
+++ b/node/10-user/Dockerfile
@@ -17,7 +17,7 @@ FROM node:10-stretch
 # Add Graphviz
 RUN set -ex; \
   apt-get update -y; \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     graphviz \
     apt-transport-https \
     ca-certificates \

--- a/node/12-user/Dockerfile
+++ b/node/12-user/Dockerfile
@@ -17,7 +17,7 @@ FROM node:12-stretch
 # Add Graphviz
 RUN set -ex; \
   apt-get update -y; \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     graphviz \
     apt-transport-https \
     ca-certificates \

--- a/node/14-user/Dockerfile
+++ b/node/14-user/Dockerfile
@@ -17,7 +17,7 @@ FROM node:14-stretch
 # Add Graphviz
 RUN set -ex; \
   apt-get update -y; \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     graphviz \
     apt-transport-https \
     ca-certificates \

--- a/python/cloud-devrel-kokoro-resources/python/Dockerfile
+++ b/python/cloud-devrel-kokoro-resources/python/Dockerfile
@@ -15,8 +15,8 @@
 FROM gcr.io/cloud-devrel-kokoro-resources/python-base:latest
 
 # Install libraries needed by third-party python packages that we depend on.
-RUN apt update \
-  && apt install -y \
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
     graphviz \
     libcurl4-openssl-dev \
     libffi-dev \
@@ -33,7 +33,7 @@ RUN apt update \
     portaudio19-dev \
     python-pyaudio \
     zlib1g-dev \
- && apt clean
+ && apt-get clean
 
 RUN python --version
 RUN which python


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>