### PR TITLE
Add imagemagick package

### DIFF
--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -75,5 +75,10 @@ RUN pyenv install 3.6.1 && \
 RUN apt-get update -y && \
     apt-get install -y graphviz && \
     rm -rf /var/lib/apt/lists/*
+    
+# Add imagemagick
+RUN apt-get update -y && \
+    apt-get install -y imagemagick && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace


### PR DESCRIPTION
Required for [`functions/imagemagick` samples](https://github.com/GoogleCloudPlatform/java-docs-samples/pull/2520)

(Currently they're only running on Java 11.)