### PR TITLE
fix: correct syntax in cloudbuild.yaml files

### DIFF
--- a/elixir/cloudbuild.yaml
+++ b/elixir/cloudbuild.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+timeout: 7200s  # 2 hours
 steps:
 
 # Fetch cached plt files

--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -15,9 +15,8 @@
 # note: /workspace is a special directory in the docker image where all the files in this folder
 # get placed on your behalf
 
-steps:
-
 timeout: 7200s  # 2 hours
+steps:
 
 # Go 1.6 build
 - name: gcr.io/cloud-builders/docker

--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+timeout: 7200s  # 2 hours
 steps:
 
-timeout: 7200s  # 2 hours
 
 # Java 7 build
 - name: gcr.io/cloud-builders/docker

--- a/node/cloudbuild.yaml
+++ b/node/cloudbuild.yaml
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-steps:
-
 timeout: 7200s  # 2 hours
+steps:
 
 # Node 8
 - name: gcr.io/cloud-builders/docker

--- a/python/cloudbuild.yaml
+++ b/python/cloudbuild.yaml
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-steps:
-
 timeout: 7200s  # 2 hours
+steps:
 
 # cloud-devrel-kokoro-resources/google-cloud-python/autosynth
 - name: gcr.io/cloud-builders/docker

--- a/ruby/cloudbuild.yaml
+++ b/ruby/cloudbuild.yaml
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-steps:
-
 timeout: 7200s  # 2 hours
+steps:
 
 # Ruby Autosynth
 - name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
Actually tested this time with `gcloud builds submit --config python/cloudbuild.yaml .` 😅 

On the bright side all the triggers seem to have been setup correctly https://github.com/googleapis/testing-infra-docker/commit/c1b64b41139e4069a64fa5b030c729ad797eac68

![image](https://user-images.githubusercontent.com/8822365/80433580-2c777480-88ac-11ea-89dc-5f5ff0a91520.png)
