### PR TITLE
fix(java): use --force-yes on apt-get install for java 7

### DIFF
--- a/java/java7/Dockerfile
+++ b/java/java7/Dockerfile
@@ -62,7 +62,7 @@ RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install pyenv
-RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+RUN apt-get install -y --force-yes make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python-openssl
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv


### PR DESCRIPTION
Should fixes: 
```
Step #0 - "java7-build": 17 upgraded, 102 newly installed, 0 to remove and 88 not upgraded.
Step #0 - "java7-build": Need to get 76.6 MB of archives.
Step #0 - "java7-build": After this operation, 278 MB of additional disk space will be used.
Step #0 - "java7-build": WARNING: The following packages cannot be authenticated!
Step #0 - "java7-build":   ncurses-bin libtinfo5 libncursesw5 libncurses5 libpipeline1 libisl10
Step #0 - "java7-build":   libcloog-isl4 libfontenc1 libmpfr4 libtcl8.6 libxft2 libxss1 libtk8.6
Step #0 - "java7-build":   libxmu6 libxaw7 libxcb-shape0 libxmuu1 libxv1 libxxf86dga1 libmpc3
Step #0 - "java7-build":   init-system-helpers manpages binfmt-support binutils cpp gcc g++ make
Step #0 - "java7-build":   libtimedate-perl libdpkg-perl dpkg-dev build-essential libfakeroot fakeroot
Step #0 - "java7-build":   libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl
Step #0 - "java7-build":   libfile-fcntllock-perl libpng12-dev pkg-config liblzma-dev libtinfo-dev
Step #0 - "java7-build":   libncurses5-dev libncursesw5-dev libreadline6-dev libreadline-dev
Step #0 - "java7-build":   libutempter0 x11proto-xext-dev libxext-dev x11proto-render-dev
Step #0 - "java7-build":   libxrender-dev libxft-dev x11proto-scrnsaver-dev libxss-dev llvm-3.5-runtime
Step #0 - "java7-build":   llvm-runtime llvm-3.5 llvm llvm-3.5-dev manpages-dev python-ply
Step #0 - "java7-build":   python-pycparser python-cffi python-pkg-resources python-cryptography
Step #0 - "java7-build":   python-openssl tcl8.6 tcl tcl8.6-dev tcl-dev tk8.6 tk tk8.6-dev tk-dev
Step #0 - "java7-build":   x11-utils xbitmaps xterm
Step #0 - "java7-build": [91mE[0m[91m: There are problems and -y was used without --force-yes
```