### PR TITLE
fix(java): fix paths to structure_test yaml configs

### DIFF
--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -12,85 +12,111 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 7200s  # 2 hours
+timeout: 7200s # 2 hours
 steps:
+  # Java 7 build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java7", "."]
+    dir: java/java7
+    id: java7-build
+    waitFor: ["-"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "gcr.io/$PROJECT_ID/java7", "--config", "java/java7.yaml", "-v"]
+    waitFor: ["java7-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "tag",
+        "gcr.io/$PROJECT_ID/java7",
+        "gcr.io/cloud-devrel-public-resources/java7",
+      ]
+    waitFor: ["java7-build"]
 
+  # Java 8 build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java8", "."]
+    dir: java/java8
+    id: java8-build
+    waitFor: ["-"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "gcr.io/$PROJECT_ID/java8", "--config", "java/java8.yaml", "-v"]
+    waitFor: ["java8-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "tag",
+        "gcr.io/$PROJECT_ID/java8",
+        "gcr.io/cloud-devrel-public-resources/java8",
+      ]
+    waitFor: ["java8-build"]
 
-# Java 7 build
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/java7', '.']
-  dir: java/java7
-  id: java7-build
-  waitFor: ['-']
-- name: gcr.io/gcp-runtimes/structure_test
-  args: ['-i', 'gcr.io/$PROJECT_ID/java7', '--config', 'java7.yaml', '-v']
-  waitFor: ['java7-build']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/$PROJECT_ID/java7', 'gcr.io/cloud-devrel-public-resources/java7']
-  waitFor: ['java7-build']
+  # Java 9 build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java9", "."]
+    dir: java/java9
+    id: java9-build
+    waitFor: ["-"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "gcr.io/$PROJECT_ID/java9", "--config", "java/java9.yaml", "-v"]
+    waitFor: ["java9-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "tag",
+        "gcr.io/$PROJECT_ID/java9",
+        "gcr.io/cloud-devrel-public-resources/java9",
+      ]
+    waitFor: ["java9-build"]
 
-# Java 8 build
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/java8', '.']
-  dir: java/java8
-  id: java8-build
-  waitFor: ['-']
-- name: gcr.io/gcp-runtimes/structure_test
-  args: ['-i', 'gcr.io/$PROJECT_ID/java8', '--config', 'java8.yaml', '-v']
-  waitFor: ['java8-build']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/$PROJECT_ID/java8', 'gcr.io/cloud-devrel-public-resources/java8']
-  waitFor: ['java8-build']
+  # Java 10 build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java10", "."]
+    dir: java/java10
+    id: java10-build
+    waitFor: ["-"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "gcr.io/$PROJECT_ID/java10", "--config", "java/java10.yaml", "-v"]
+    waitFor: ["java10-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "tag",
+        "gcr.io/$PROJECT_ID/java10",
+        "gcr.io/cloud-devrel-public-resources/java10",
+      ]
+    waitFor: ["java10-build"]
 
-# Java 9 build
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/java9', '.']
-  dir: java/java9
-  id: java9-build
-  waitFor: ['-']
-- name: gcr.io/gcp-runtimes/structure_test
-  args: ['-i', 'gcr.io/$PROJECT_ID/java9', '--config', 'java9.yaml', '-v']
-  waitFor: ['java9-build']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/$PROJECT_ID/java9', 'gcr.io/cloud-devrel-public-resources/java9']
-  waitFor: ['java9-build']
-
-
-# Java 10 build
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/java10', '.']
-  dir: java/java10
-  id: java10-build
-  waitFor: ['-']
-- name: gcr.io/gcp-runtimes/structure_test
-  args: ['-i', 'gcr.io/$PROJECT_ID/java10', '--config', 'java10.yaml', '-v']
-  waitFor: ['java10-build']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/$PROJECT_ID/java10', 'gcr.io/cloud-devrel-public-resources/java10']
-  waitFor: ['java10-build']
-
-
-# Java 11 build
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/java11', '.']
-  dir: java/java11
-  id: java11-build
-  waitFor: ['-']
-- name: gcr.io/gcp-runtimes/structure_test
-  args: ['-i', 'gcr.io/$PROJECT_ID/java11', '--config', 'java11.yaml', '-v']
-  waitFor: ['java11-build']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/$PROJECT_ID/java11', 'gcr.io/cloud-devrel-public-resources/java11']
-  waitFor: ['java11-build']
+  # Java 11 build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java11", "."]
+    dir: java/java11
+    id: java11-build
+    waitFor: ["-"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "gcr.io/$PROJECT_ID/java11", "--config", "java/java11.yaml", "-v"]
+    waitFor: ["java11-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "tag",
+        "gcr.io/$PROJECT_ID/java11",
+        "gcr.io/cloud-devrel-public-resources/java11",
+      ]
+    waitFor: ["java11-build"]
 
 images:
-- gcr.io/$PROJECT_ID/java7
-- gcr.io/cloud-devrel-public-resources/java7
-- gcr.io/$PROJECT_ID/java8
-- gcr.io/cloud-devrel-public-resources/java8
-- gcr.io/$PROJECT_ID/java9
-- gcr.io/cloud-devrel-public-resources/java9
-- gcr.io/$PROJECT_ID/java10
-- gcr.io/cloud-devrel-public-resources/java10
-- gcr.io/$PROJECT_ID/java11
-- gcr.io/cloud-devrel-public-resources/java11
+  - gcr.io/$PROJECT_ID/java7
+  - gcr.io/cloud-devrel-public-resources/java7
+  - gcr.io/$PROJECT_ID/java8
+  - gcr.io/cloud-devrel-public-resources/java8
+  - gcr.io/$PROJECT_ID/java9
+  - gcr.io/cloud-devrel-public-resources/java9
+  - gcr.io/$PROJECT_ID/java10
+  - gcr.io/cloud-devrel-public-resources/java10
+  - gcr.io/$PROJECT_ID/java11
+  - gcr.io/cloud-devrel-public-resources/java11


### PR DESCRIPTION
At some point, cloudbuild started running from the root of the project, not from the location of the cloudbuild.yaml. Thus we need to specify the structure_test yaml path as java/java[version].yaml.

I actually ran this one and it completed successfully. Note that my IDE reformatted the yaml file with `prettier`