### PR TITLE
fix: Disable build of the Ruby images

### DIFF
--- a/ruby/cloudbuild.yaml
+++ b/ruby/cloudbuild.yaml
@@ -33,7 +33,11 @@ steps:
   dir: 'ruby/ruby-release'
   waitFor: ['-']
 
-images:
-  - gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/autosynth
-  - gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi
-  - gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-release
+# TODO(dazuma): Re-enable upload of these images (or remove them altogether
+# from this repo) AFTER they have been consolidated with the images in
+# googleapis/google-cloud-ruby.
+
+# images:
+#   - gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/autosynth
+#   - gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi
+#   - gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-release


### PR DESCRIPTION
The canonical Ruby images are actually elsewhere, in https://github.com/googleapis/google-cloud-ruby. The images currently in testing-infra-docker are out of date and can break Ruby CI if they are built. Disable upload of these images for now to prevent that. We still need to figure out how to reconcile the two sets of images.