### PR TITLE
Ruby gem no doc tweak

### DIFF
--- a/ruby/autosynth/Dockerfile
+++ b/ruby/autosynth/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN rbenv install 2.6.5 && rbenv global 2.6.5 \
     && gem install bundler:1.17.3 bundler:2.0.2 rake
 

--- a/ruby/ruby-multi/Dockerfile
+++ b/ruby/ruby-multi/Dockerfile
@@ -48,7 +48,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 ENV RUBY_VERSIONS "2.4.9 2.5.7 2.6.5"
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN for version in ${RUBY_VERSIONS}; do \
         rbenv install "$version" && rbenv global "$version" && \
         gem install bundler:1.17.3 bundler:2.0.2 && gem update --system \

--- a/ruby/ruby-release/Dockerfile
+++ b/ruby/ruby-release/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
 RUN $HOME/.ruby-build/bin/ruby-build 2.6.5 $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN gem install bundler:1.17.3 bundler:2.0.2 rake && gem update --system
 
 # Install Python

--- a/ruby/windows/Dockerfile
+++ b/ruby/windows/Dockerfile
@@ -49,6 +49,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls'; \
 
 RUN C:\Ruby25-x64\bin\ridk install 1 2 3
 
-RUN gem install bundler:1.17.3
+RUN gem install --no-document bundler:1.17.3
 
 RUN gem update --system


### PR DESCRIPTION
Optimization tweak for ruby gems no doc while gems installation using
 "--no-document" . Also removal of depricated "--no-ri" and "--no-rdoc".

 More detail can be found at
 https://guides.rubygems.org/command-reference/#installupdate-options-2

 Signed-off-by: Pratik raj <rajpratik71@gmail.com>