### PR TITLE
chore: ignore Go Dockerfile Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
+  ],
+  "ignorePaths": [
+    "go/*/Dockerfile"
   ]
 }


### PR DESCRIPTION
This will prevent PRs like #57. We don't want to upgrade the Go version in the testing images.