### PR TITLE
chore: Use `--no-cache-dir` flag to `pip` in Dockerfiles, to save space

### DIFF
--- a/conformance-tests/storage/retry/Dockerfile
+++ b/conformance-tests/storage/retry/Dockerfile
@@ -18,6 +18,6 @@ WORKDIR /opt/storage-emulator
 
 COPY google-cloud-cpp/google/cloud/storage/emulator /opt/storage-emulator/
 
-RUN python3 -m pip install -r requirements.txt
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 CMD ["gunicorn", "--bind", "localhost:9000", "--worker-class", "sync", "emulator:run()"]

--- a/go/go115/Dockerfile
+++ b/go/go115/Dockerfile
@@ -49,7 +49,7 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
     pyenv install ${PYTHON_VERSION} && \
     pyenv global ${PYTHON_VERSION} && \
-    python3 -m pip install --upgrade pip setuptools; done
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools; done
 
 # Install protoc
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip

--- a/go/go116/Dockerfile
+++ b/go/go116/Dockerfile
@@ -48,7 +48,7 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
     pyenv install ${PYTHON_VERSION} && \
     pyenv global ${PYTHON_VERSION} && \
-    python3 -m pip install --upgrade pip setuptools; done
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools; done
 
 # Install protoc
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -69,7 +69,7 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 # Install python
 RUN pyenv install 3.6.12 && \
     pyenv global 3.6.12 && \
-    python3 -m pip install --upgrade pip setuptools
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools
 
 # Add Graphviz
 RUN apt-get update -y && \

--- a/java/java7/Dockerfile
+++ b/java/java7/Dockerfile
@@ -77,7 +77,7 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 # Install python
 RUN pyenv install 3.6.1 && \
     pyenv global 3.6.1 && \
-    python3 -m pip install --upgrade pip setuptools
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools
 
 # Install docker
 RUN apt-get update && apt-get install -y --force-yes \

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -69,9 +69,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 # Install python
 RUN pyenv install 3.6.12 && \
     pyenv global 3.6.12 && \
-    python3 -m pip install --upgrade pip setuptools
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools
 
-# Install docker
 # Install docker
 RUN apt-get update && apt-get install -y \
         apt-transport-https \

--- a/python/cloud-devrel-kokoro-resources/google-cloud-python/autosynth/Dockerfile
+++ b/python/cloud-devrel-kokoro-resources/google-cloud-python/autosynth/Dockerfile
@@ -20,5 +20,5 @@ ENTRYPOINT /bin/bash
 RUN pyenv install 3.7.2
 RUN pyenv global 3.7.2
 
-RUN python3 -m pip install nox
+RUN python3 -m pip install --no-cache-dir nox
 RUN pyenv rehash

--- a/python/cloud-devrel-kokoro-resources/python/Dockerfile
+++ b/python/cloud-devrel-kokoro-resources/python/Dockerfile
@@ -51,6 +51,6 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 ENV PATH ~/.local/bin:/root/.local/bin:$PATH
 
 # Install the current version of nox.
-RUN python3 -m pip install --user --no-cache-dir nox==2020.8.22
+RUN python3 -m pip install --no-cache-dir --user --no-cache-dir nox==2020.8.22
 
 CMD ["nox"]


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>