### PR TITLE
fix: add libxss1 for Chrome

### DIFF
--- a/node/12-puppeteer/Dockerfile
+++ b/node/12-puppeteer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont libxss1 \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge --auto-remove -y curl \


### PR DESCRIPTION
After some unknown change headless Chrome now requires `libXss1.so.1`. Let's add it into our browser testing Docker image.

@busunkim96 or @bcoe, after this one is merged, I will need your folks' help in deploying this updated image :)  I don't think I have access to that gcr.io project. Thank you!