### PR TITLE
fix: add libxtst6 for Chrome

### DIFF
--- a/node/12-puppeteer/Dockerfile
+++ b/node/12-puppeteer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont libxss1 \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont libxss1 libxtst6 \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge --auto-remove -y curl \


### PR DESCRIPTION
Apparently it now needs this one as well.

```
02 09 2020 17:25:49.233:ERROR [launcher]: ChromeHeadless stdout: 
02 09 2020 17:25:49.233:ERROR [launcher]: ChromeHeadless stderr: /tmpfs/src/github/gax-nodejs/node_modules/puppeteer/.local-chromium/linux-782078/chrome-linux/chrome: error while loading shared libraries: libXtst.so.6: cannot open shared object file: No such file or directory
```

I hope this is the last one, but let's see :)