### PR TITLE
fix(python): ensure pip for 3.9

### DIFF
--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -163,8 +163,8 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
   # https://github.com/docker-library/python/pull/100
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
-# Ensure Pip for 3.8.0
-RUN python3.8 /tmp/get-pip.py
+# Ensure Pip for 3.9
+RUN python3.9 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
 
 # Install "virtualenv", since the vast majority of users of this image


### PR DESCRIPTION
This ensures that `python3 -m pip ...` works as expected.