### PR TITLE
chore(ruby): install memcached

### DIFF
--- a/ruby/multi/Dockerfile
+++ b/ruby/multi/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update \
       libssl1.0-dev \
       libyaml-dev \
       make \
+      memcached \
       pkg-config \
       python-openssl \
       software-properties-common \


### PR DESCRIPTION
ruby-docs-samples uses memcached in its ci flow