### PR TITLE
fix(ruby): Make root readable so Trampoline V2 jobs can use it

### DIFF
--- a/ruby/multi/Dockerfile
+++ b/ruby/multi/Dockerfile
@@ -141,3 +141,6 @@ RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x
     && tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share/ \
     && ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/ \
     && rm phantomjs-2.1.1-linux-x86_64.tar.bz2
+
+# Allow non-root users read access to /root (for Trampoline V2)
+RUN chmod -v a+rx /root


### PR DESCRIPTION
Trampoline V2 runs scripts as an unprivileged user. However, the Ruby image installs a bunch of things (notably including Ruby itself) into `/root` which is by default unreadable by any user except root. We'll loosen that a bit and allow other users to read and navigate into that directory, to make the image usable by Trampoline V2.
