### PR TITLE
chore(go): install both python v3.7 and 3.8 in go116

### DIFF
--- a/go/go116/Dockerfile
+++ b/go/go116/Dockerfile
@@ -28,10 +28,11 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
-# Install Python 3.8 for trampoline.
-RUN pyenv install 3.8.8 && \
-    pyenv global 3.8.8 && \
-    python3 -m pip install --upgrade pip setuptools
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim


### PR DESCRIPTION
Problem: 
Our nox test suite for google-cloud-go/logging currently requires Python 3.7, and will require Python 3.8 shortly. See [test suite](https://github.com/googleapis/env-tests-logging)

Solution: 
This PR installs latest versions for Python & pip in `3.7` and `3.8` via the `pyenv` util. It defaults to version 3.8. 
Though in the container, users can chose which version to use by: `pyenv global VERSION`. 

This installation step now takes ~3 minutes (tried it locally). 

The alternative to this PR is that I revert #125 to just install python 3.7 by default, but I'll still need Python3.8 in this image at some point in the near future. Open to suggestions! 



