### PR TITLE
feat(go): add docker and pyenv to all go test images

### DIFF
--- a/go/go111/Dockerfile
+++ b/go/go111/Dockerfile
@@ -14,8 +14,41 @@
 
 FROM golang:1.11
 
-# Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/go/go112/Dockerfile
+++ b/go/go112/Dockerfile
@@ -14,8 +14,41 @@
 
 FROM golang:1.12
 
-# Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/go/go113/Dockerfile
+++ b/go/go113/Dockerfile
@@ -14,8 +14,41 @@
 
 FROM golang:1.13
 
-# Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/go/go114/Dockerfile
+++ b/go/go114/Dockerfile
@@ -14,8 +14,41 @@
 
 FROM golang:1.14
 
-# Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/go/go115/Dockerfile
+++ b/go/go115/Dockerfile
@@ -14,8 +14,42 @@
 
 FROM golang:1.15
 
-# Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
 RUN apt-get update && apt-get install -y unzip wget vim

--- a/go/go116/Dockerfile
+++ b/go/go116/Dockerfile
@@ -14,11 +14,27 @@
 
 FROM golang:1.16
 
-# Install pyenv
-RUN apt-get update
-RUN apt-get install -y --force-yes make build-essential libssl-dev zlib1g-dev libbz2-dev \
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
 ENV PATH /root/.pyenv/bin:$PATH
@@ -35,7 +51,6 @@ RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
     python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
-RUN apt-get update && apt-get install -y unzip wget vim
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip
 RUN unzip protoc-3.13.0-linux-x86_64.zip
 RUN mv bin/protoc /bin/protoc && which protoc


### PR DESCRIPTION
Changes: 

- [x] Add pyenv flexible python version manager to all go images (not just go116 previously)
- [x] Add docker in test images for all versions
- [x] Clean up large file after `apt-get update` , run update only once, as an optimization