### PR TITLE
chore: add docker to go115 and go116

### DIFF
--- a/go/go115/Dockerfile
+++ b/go/go115/Dockerfile
@@ -14,11 +14,44 @@
 
 FROM golang:1.15
 
-# Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
-RUN apt-get update && apt-get install -y unzip wget vim
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip
 RUN unzip protoc-3.7.1-linux-x86_64.zip
 RUN mv bin/protoc /bin/protoc && which protoc

--- a/go/go116/Dockerfile
+++ b/go/go116/Dockerfile
@@ -14,11 +14,27 @@
 
 FROM golang:1.16
 
-# Install pyenv
-RUN apt-get update
-RUN apt-get install -y --force-yes make build-essential libssl-dev zlib1g-dev libbz2-dev \
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
 ENV PATH /root/.pyenv/bin:$PATH
@@ -35,7 +51,6 @@ RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
     python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
-RUN apt-get update && apt-get install -y unzip wget vim
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip
 RUN unzip protoc-3.13.0-linux-x86_64.zip
 RUN mv bin/protoc /bin/protoc && which protoc


### PR DESCRIPTION
Splitting up making these changes to go versions to avoid gcbrun timeout

Changes:

- Add pyenv flexible python version manager to all go images (not just go116 previously)
-  Add docker in test images for all versions
-  Clean up large file after apt-get update, run apt-update only once, as an optimization

Reason: 
I need docker and docker-cli in environment tests. And it seems to be an open issue [here](https://github.com/googleapis/testing-infra-docker/issues/16). This docker-in-docker feature currently exists for go image with [Java](https://github.com/googleapis/testing-infra-docker/blob/5ac625a7949d71846c1ea9306fe4267ae5abe0ba/java/java11/Dockerfile#L85), [Python](https://github.com/googleapis/testing-infra-docker/blob/5ac625a7949d71846c1ea9306fe4267ae5abe0ba/python/googleapis/python-multi/Dockerfile#L95), and I recently also added it to [node](https://github.com/googleapis/testing-infra-docker/blob/5ac625a7949d71846c1ea9306fe4267ae5abe0ba/node/14-user/Dockerfile#L32)