### PR TITLE
chore(go): add pyenv and docker to go113 go114

### DIFF
--- a/go/go113/Dockerfile
+++ b/go/go113/Dockerfile
@@ -14,11 +14,43 @@
 
 FROM golang:1.13
 
-# Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
-RUN apt-get update && apt-get install -y unzip wget vim
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip
 RUN unzip protoc-3.7.1-linux-x86_64.zip
 RUN mv bin/protoc /bin/protoc && which protoc

--- a/go/go114/Dockerfile
+++ b/go/go114/Dockerfile
@@ -14,11 +14,43 @@
 
 FROM golang:1.14
 
-# Install python3 for trampoline.
-RUN apt-get update && apt-get install -y python3 python3-pip && which python3
+# Install dependencies
+RUN set -ex; \
+  apt-get update -y; \
+  apt-get install -y \
+    make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    apt-transport-https ca-certificates curl gnupg-agent lsb-release software-properties-common \
+    unzip wget vim; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install Python 3.7 & 3.8, defaults to 3.8
+RUN for PYTHON_VERSION in 3.7.10 3.8.8; do \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
+    python3 -m pip install --upgrade pip setuptools; done
 
 # Install protoc
-RUN apt-get update && apt-get install -y unzip wget vim
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip
 RUN unzip protoc-3.7.1-linux-x86_64.zip
 RUN mv bin/protoc /bin/protoc && which protoc


### PR DESCRIPTION
Similar to #129, adding conformance to other go images. Submitting as separate PRs to avoid presubmit timeout

Note: I actually don't use these images for our tests, but figured we wanted parity among all image versions