### PR TITLE
chore(go): increase Go build timeout to 2 hours

### DIFF
--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -15,7 +15,7 @@
 # note: /workspace is a special directory in the docker image where all the files in this folder
 # get placed on your behalf
 
-timeout: 3600s
+timeout: 7200s  # 2 hours
 steps:
 # Go 1.11 build
 - name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
Fixes: failed CloudRun release for Go: https://github.com/googleapis/testing-infra-docker/runs/2290139583
It finished building 115, then timed out before completing go116

Increasing timeout from 1 hour to 2 hours, similar to Python, Ruby, etc.