### PR TITLE
fix(ruby): Set additional environment variables for Ruby CI

### DIFF
--- a/ruby/multi/Dockerfile
+++ b/ruby/multi/Dockerfile
@@ -17,6 +17,8 @@ FROM ubuntu:bionic
 ENTRYPOINT /bin/bash
 
 ENV RUBY_VERSIONS="2.5.8 2.6.6 2.7.2 3.0.0" \
+    OLDEST_RUBY_VERSION=2.5.8 \
+    NEWEST_RUBY_VERSION=3.0.0 \
     DEFAULT_RUBY_VERSION=2.6.6 \
     BUNDLER1_VERSION=1.17.3 \
     BUNDLER2_VERSION=2.2.11 \
@@ -85,11 +87,12 @@ RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubunt
     && apt-get -y autoclean
 
 # Install rbenv
-RUN git clone --depth=1 https://github.com/rbenv/rbenv.git /root/.rbenv \
-    && cd /root/.rbenv \
+ENV RBENV_ROOT=/root/.rbenv
+RUN git clone --depth=1 https://github.com/rbenv/rbenv.git $RBENV_ROOT \
+    && cd $RBENV_ROOT \
     && src/configure \
     && make -C src
-ENV PATH /root/.rbenv/shims:/root/.rbenv/bin:$PATH
+ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 RUN echo 'eval "$(rbenv init -)"' >> /etc/profile
 RUN echo 'eval "$(rbenv init -)"' >> .bashrc
 RUN mkdir -p "$(rbenv root)"/plugins \
@@ -107,11 +110,12 @@ RUN for version in ${RUBY_VERSIONS}; do \
     && rbenv global ${DEFAULT_RUBY_VERSION}
 
 # Install pyenv
-RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ~/.pyenv \
-    && cd /root/.pyenv \
+ENV PYENV_ROOT=/root/.pyenv
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && cd $PYENV_ROOT \
     && src/configure \
     && make -C src
-ENV PATH /root/.pyenv/shims:/root/.pyenv/bin:$PATH
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc
 RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc
 RUN echo 'eval "$(pyenv init -)"' >> ~/.bashrc
@@ -122,11 +126,12 @@ RUN pyenv install ${PYTHON_VERSION} \
     && ln -s $(which python) /bin/python3
 
 # Install nodenv
-RUN git clone --depth=1 https://github.com/nodenv/nodenv.git ~/.nodenv \
-    && cd /root/.nodenv \
+ENV NODENV_ROOT=/root/.nodenv
+RUN git clone --depth=1 https://github.com/nodenv/nodenv.git $NODENV_ROOT \
+    && cd $NODENV_ROOT \
     && src/configure \
     && make -C src
-ENV PATH /root/.nodenv/shims:/root/.nodenv/bin:$PATH
+ENV PATH $NODENV_ROOT/shims:$NODENV_ROOT/bin:$PATH
 RUN echo 'export PATH="$HOME/.nodenv/bin:$PATH"' >> ~/.bashrc
 RUN echo 'eval "$(nodenv init -)"' >> ~/.bashrc
 RUN mkdir -p "$(nodenv root)"/plugins \


### PR DESCRIPTION
Sets `$OLDEST_RUBY_VERSION`, `$NEWEST_RUBY_VERSION` which are used by CI scripts in google-cloud-ruby to decide "semantically" which Ruby versions to use. Also sets `$RBENV_ROOT`, `$PYENV_ROOT`, and `$NODENV_ROOT` which are needed to run those languages as a nonprivileged user.