### PR TITLE
fix(java): upgrade python from 3.6.1 to 3.6.12, stop building non-LTS java versions

### DIFF
--- a/java/cloudbuild-test.yaml
+++ b/java/cloudbuild-test.yaml
@@ -14,25 +14,6 @@
 
 timeout: 7200s # 2 hours
 steps:
-  # Java 7 build
-  # - name: gcr.io/cloud-builders/docker
-  #   args: ["build", "-t", "gcr.io/$PROJECT_ID/java7", "."]
-  #   dir: java/java7
-  #   id: java7-build
-  #   waitFor: ["-"]
-  # - name: gcr.io/gcp-runtimes/structure_test
-  #   args:
-  #     ["-i", "gcr.io/$PROJECT_ID/java7", "--config", "java/java7.yaml", "-v"]
-  #   waitFor: ["java7-build"]
-  # - name: gcr.io/cloud-builders/docker
-  #   args:
-  #     [
-  #       "tag",
-  #       "gcr.io/$PROJECT_ID/java7",
-  #       "gcr.io/cloud-devrel-public-resources/java7",
-  #     ]
-  #   waitFor: ["java7-build"]
-
   # Java 8 build
   - name: gcr.io/cloud-builders/docker
     args: ["build", "-t", "gcr.io/$PROJECT_ID/java8", "."]
@@ -51,44 +32,6 @@ steps:
         "gcr.io/cloud-devrel-public-resources/java8",
       ]
     waitFor: ["java8-build"]
-
-  # Java 9 build
-  - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/java9", "."]
-    dir: java/java9
-    id: java9-build
-    waitFor: ["-"]
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      ["-i", "gcr.io/$PROJECT_ID/java9", "--config", "java/java9.yaml", "-v"]
-    waitFor: ["java9-build"]
-  - name: gcr.io/cloud-builders/docker
-    args:
-      [
-        "tag",
-        "gcr.io/$PROJECT_ID/java9",
-        "gcr.io/cloud-devrel-public-resources/java9",
-      ]
-    waitFor: ["java9-build"]
-
-  # Java 10 build
-  - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/java10", "."]
-    dir: java/java10
-    id: java10-build
-    waitFor: ["-"]
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      ["-i", "gcr.io/$PROJECT_ID/java10", "--config", "java/java10.yaml", "-v"]
-    waitFor: ["java10-build"]
-  - name: gcr.io/cloud-builders/docker
-    args:
-      [
-        "tag",
-        "gcr.io/$PROJECT_ID/java10",
-        "gcr.io/cloud-devrel-public-resources/java10",
-      ]
-    waitFor: ["java10-build"]
 
   # Java 11 build
   - name: gcr.io/cloud-builders/docker

--- a/java/cloudbuild-test.yaml
+++ b/java/cloudbuild-test.yaml
@@ -15,23 +15,23 @@
 timeout: 7200s # 2 hours
 steps:
   # Java 7 build
-  - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/java7", "."]
-    dir: java/java7
-    id: java7-build
-    waitFor: ["-"]
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      ["-i", "gcr.io/$PROJECT_ID/java7", "--config", "java/java7.yaml", "-v"]
-    waitFor: ["java7-build"]
-  - name: gcr.io/cloud-builders/docker
-    args:
-      [
-        "tag",
-        "gcr.io/$PROJECT_ID/java7",
-        "gcr.io/cloud-devrel-public-resources/java7",
-      ]
-    waitFor: ["java7-build"]
+  # - name: gcr.io/cloud-builders/docker
+  #   args: ["build", "-t", "gcr.io/$PROJECT_ID/java7", "."]
+  #   dir: java/java7
+  #   id: java7-build
+  #   waitFor: ["-"]
+  # - name: gcr.io/gcp-runtimes/structure_test
+  #   args:
+  #     ["-i", "gcr.io/$PROJECT_ID/java7", "--config", "java/java7.yaml", "-v"]
+  #   waitFor: ["java7-build"]
+  # - name: gcr.io/cloud-builders/docker
+  #   args:
+  #     [
+  #       "tag",
+  #       "gcr.io/$PROJECT_ID/java7",
+  #       "gcr.io/cloud-devrel-public-resources/java7",
+  #     ]
+  #   waitFor: ["java7-build"]
 
   # Java 8 build
   - name: gcr.io/cloud-builders/docker

--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -15,23 +15,23 @@
 timeout: 7200s # 2 hours
 steps:
   # Java 7 build
-  - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/java7", "."]
-    dir: java/java7
-    id: java7-build
-    waitFor: ["-"]
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      ["-i", "gcr.io/$PROJECT_ID/java7", "--config", "java/java7.yaml", "-v"]
-    waitFor: ["java7-build"]
-  - name: gcr.io/cloud-builders/docker
-    args:
-      [
-        "tag",
-        "gcr.io/$PROJECT_ID/java7",
-        "gcr.io/cloud-devrel-public-resources/java7",
-      ]
-    waitFor: ["java7-build"]
+  # - name: gcr.io/cloud-builders/docker
+  #   args: ["build", "-t", "gcr.io/$PROJECT_ID/java7", "."]
+  #   dir: java/java7
+  #   id: java7-build
+  #   waitFor: ["-"]
+  # - name: gcr.io/gcp-runtimes/structure_test
+  #   args:
+  #     ["-i", "gcr.io/$PROJECT_ID/java7", "--config", "java/java7.yaml", "-v"]
+  #   waitFor: ["java7-build"]
+  # - name: gcr.io/cloud-builders/docker
+  #   args:
+  #     [
+  #       "tag",
+  #       "gcr.io/$PROJECT_ID/java7",
+  #       "gcr.io/cloud-devrel-public-resources/java7",
+  #     ]
+  #   waitFor: ["java7-build"]
 
   # Java 8 build
   - name: gcr.io/cloud-builders/docker
@@ -110,8 +110,8 @@ steps:
     waitFor: ["java11-build"]
 
 images:
-  - gcr.io/$PROJECT_ID/java7
-  - gcr.io/cloud-devrel-public-resources/java7
+  # - gcr.io/$PROJECT_ID/java7
+  # - gcr.io/cloud-devrel-public-resources/java7
   - gcr.io/$PROJECT_ID/java8
   - gcr.io/cloud-devrel-public-resources/java8
   - gcr.io/$PROJECT_ID/java9

--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -14,25 +14,6 @@
 
 timeout: 7200s # 2 hours
 steps:
-  # Java 7 build
-  # - name: gcr.io/cloud-builders/docker
-  #   args: ["build", "-t", "gcr.io/$PROJECT_ID/java7", "."]
-  #   dir: java/java7
-  #   id: java7-build
-  #   waitFor: ["-"]
-  # - name: gcr.io/gcp-runtimes/structure_test
-  #   args:
-  #     ["-i", "gcr.io/$PROJECT_ID/java7", "--config", "java/java7.yaml", "-v"]
-  #   waitFor: ["java7-build"]
-  # - name: gcr.io/cloud-builders/docker
-  #   args:
-  #     [
-  #       "tag",
-  #       "gcr.io/$PROJECT_ID/java7",
-  #       "gcr.io/cloud-devrel-public-resources/java7",
-  #     ]
-  #   waitFor: ["java7-build"]
-
   # Java 8 build
   - name: gcr.io/cloud-builders/docker
     args: ["build", "-t", "gcr.io/$PROJECT_ID/java8", "."]
@@ -52,43 +33,6 @@ steps:
       ]
     waitFor: ["java8-build"]
 
-  # Java 9 build
-  - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/java9", "."]
-    dir: java/java9
-    id: java9-build
-    waitFor: ["-"]
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      ["-i", "gcr.io/$PROJECT_ID/java9", "--config", "java/java9.yaml", "-v"]
-    waitFor: ["java9-build"]
-  - name: gcr.io/cloud-builders/docker
-    args:
-      [
-        "tag",
-        "gcr.io/$PROJECT_ID/java9",
-        "gcr.io/cloud-devrel-public-resources/java9",
-      ]
-    waitFor: ["java9-build"]
-
-  # Java 10 build
-  - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/java10", "."]
-    dir: java/java10
-    id: java10-build
-    waitFor: ["-"]
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      ["-i", "gcr.io/$PROJECT_ID/java10", "--config", "java/java10.yaml", "-v"]
-    waitFor: ["java10-build"]
-  - name: gcr.io/cloud-builders/docker
-    args:
-      [
-        "tag",
-        "gcr.io/$PROJECT_ID/java10",
-        "gcr.io/cloud-devrel-public-resources/java10",
-      ]
-    waitFor: ["java10-build"]
 
   # Java 11 build
   - name: gcr.io/cloud-builders/docker
@@ -110,13 +54,7 @@ steps:
     waitFor: ["java11-build"]
 
 images:
-  # - gcr.io/$PROJECT_ID/java7
-  # - gcr.io/cloud-devrel-public-resources/java7
   - gcr.io/$PROJECT_ID/java8
   - gcr.io/cloud-devrel-public-resources/java8
-  - gcr.io/$PROJECT_ID/java9
-  - gcr.io/cloud-devrel-public-resources/java9
-  - gcr.io/$PROJECT_ID/java10
-  - gcr.io/cloud-devrel-public-resources/java10
   - gcr.io/$PROJECT_ID/java11
   - gcr.io/cloud-devrel-public-resources/java11

--- a/java/java11.yaml
+++ b/java/java11.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.6.14"]
+  expectedOutput: ["Python 3.6.12"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java11.yaml
+++ b/java/java11.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.6.1"]
+  expectedOutput: ["Python 3.6.14"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -67,8 +67,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.14 && \
-    pyenv global 3.6.14 && \
+RUN pyenv install 3.6.12 && \
+    pyenv global 3.6.12 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Add Graphviz

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -67,8 +67,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.1 && \
-    pyenv global 3.6.1 && \
+RUN pyenv install 3.6.14 && \
+    pyenv global 3.6.14 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Add Graphviz

--- a/java/java8.yaml
+++ b/java/java8.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.6.14"]
+  expectedOutput: ["Python 3.6.12"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java8.yaml
+++ b/java/java8.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.6.1"]
+  expectedOutput: ["Python 3.6.14"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -67,8 +67,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.1 && \
-    pyenv global 3.6.1 && \
+RUN pyenv install 3.6.14 && \
+    pyenv global 3.6.14 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Install docker

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -67,8 +67,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.14 && \
-    pyenv global 3.6.14 && \
+RUN pyenv install 3.6.12 && \
+    pyenv global 3.6.12 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Install docker


### PR DESCRIPTION
Some python tools are breaking because we're using a super old version of python 3.6.x and a `typing` type was added in a patch version of python.