### PR TITLE
chore: update gradle & App Engine SDK

### DIFF
--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# openjdk appears to be a newer source than AdoptOpenJDK, even though they both come from the same server.
 FROM openjdk:11-jdk
 
 RUN apt-get update && \
@@ -25,12 +26,12 @@ RUN wget -q http://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-ma
     rm /tmp/maven.tar.gz && \
     ln -s $JAVA_HOME/lib $JAVA_HOME/conf
 
-RUN wget -q https://services.gradle.org/distributions/gradle-4.9-bin.zip -O /tmp/gradle.zip && \
+RUN wget -q https://services.gradle.org/distributions/gradle-6.9-bin.zip -O /tmp/gradle.zip && \
     mkdir -p /usr/local/lib/gradle && \
     unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
     rm /tmp/gradle.zip
 
-ENV PATH $PATH:/usr/local/lib/maven/bin:/usr/local/lib/gradle/gradle-4.9/bin
+ENV PATH $PATH:/usr/local/lib/maven/bin:/usr/local/lib/gradle/gradle-6.9/bin
 
 # Install gcloud SDK
 RUN mkdir -p /usr/local/gcloud && \
@@ -48,7 +49,7 @@ RUN mkdir -p /tmp/playservices && \
         -Dpackaging=jar
 
 # Install the appengine SDK
-RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65
+RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.90
 
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -74,7 +74,7 @@ RUN pyenv install 3.6.12 && \
 # Install docker
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        "deb [arch=amd64] https://download.docker.com/linux/debian/dists/buster/ \
         $(lsb_release -cs) \
         stable" && \
     apt-get update && \

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -19,13 +19,13 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libxml2-utils && \
     rm -rf /var/cache/apt
 
-RUN wget -q https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -O /tmp/maven.tar.gz && \
+RUN curl -sS https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -o /tmp/maven.tar.gz && \
     mkdir -p /usr/local/lib/maven && \
     tar xzf /tmp/maven.tar.gz -C /usr/local/lib/maven --strip-components=1 && \
     rm /tmp/maven.tar.gz && \
     ln -s $JAVA_HOME/lib $JAVA_HOME/conf
 
-RUN wget -q https://services.gradle.org/distributions/gradle-6.9-bin.zip -O /tmp/gradle.zip && \
+RUN curl -sS https://services.gradle.org/distributions/gradle-6.9-bin.zip -o /tmp/gradle.zip && \
     mkdir -p /usr/local/lib/gradle && \
     unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
     rm /tmp/gradle.zip
@@ -38,7 +38,7 @@ RUN mkdir -p /usr/local/gcloud && \
 
 # Install google-play-services version 1
 RUN mkdir -p /tmp/playservices && \
-    wget -q https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -O /tmp/play-services-basement.aar && \
+    curl -sSL https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -o /tmp/play-services-basement.aar && \
     unzip -q /tmp/play-services-basement.aar -d /tmp/playservices && \
     mvn install:install-file \
         -Dfile=/tmp/playservices/classes.jar \

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -23,13 +23,13 @@ RUN apt-get update && \
     rm -rf /var/cache/apt && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sS https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -o /tmp/maven.tar.gz && \
+RUN curl -sSL https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -o /tmp/maven.tar.gz && \
     mkdir -p /usr/local/lib/maven && \
     tar xzf /tmp/maven.tar.gz -C /usr/local/lib/maven --strip-components=1 && \
     rm /tmp/maven.tar.gz && \
     ln -s $JAVA_HOME/lib $JAVA_HOME/conf
 
-RUN curl -sS https://services.gradle.org/distributions/gradle-6.9-bin.zip -o /tmp/gradle.zip && \
+RUN curl -sSL https://services.gradle.org/distributions/gradle-6.9-bin.zip -o /tmp/gradle.zip && \
     mkdir -p /usr/local/lib/gradle && \
     unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
     rm /tmp/gradle.zip

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -16,8 +16,12 @@ FROM adoptopenjdk:11-jdk
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends libxml2-utils && \
-    rm -rf /var/cache/apt
+    apt-get install -y libxml2-utils make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl graphviz imagemagick unzip \
+    apt-transport-https ca-certificates gnupg-agent lsb-release software-properties-common && \
+    rm -rf /var/cache/apt && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -o /tmp/maven.tar.gz && \
     mkdir -p /usr/local/lib/maven && \
@@ -54,13 +58,9 @@ RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install pyenv
-RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
-    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
-ENV PATH /root/.pyenv/bin:$PATH
-ENV PATH /root/.pyenv/shims:$PATH
+ENV PATH /root/.pyenv/shims:/root/.pyenv/bin:$PATH
 
 RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
@@ -70,26 +70,9 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
 RUN pyenv install 3.6.12 && \
     pyenv global 3.6.12 && \
     python3 -m pip install --upgrade pip setuptools
-
-# Add Graphviz
-RUN apt-get update -y && \
-    apt-get install -y graphviz && \
-    rm -rf /var/lib/apt/lists/*
     
-# Add imagemagick
-RUN apt-get update -y && \
-    apt-get install -y imagemagick && \
-    rm -rf /var/lib/apt/lists/*
-
 # Install docker
-RUN apt-get update && apt-get install -y \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg-agent \
-        lsb-release \
-        software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
         "deb [arch=amd64] https://download.docker.com/linux/debian \
         $(lsb_release -cs) \

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y libxml2-utils make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl graphviz imagemagick unzip \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl graphviz imagemagick unzip git \
     apt-transport-https ca-certificates gnupg-agent lsb-release software-properties-common && \
     rm -rf /var/cache/apt && \
     rm -rf /var/lib/apt/lists/*

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# openjdk appears to be a newer source than AdoptOpenJDK, even though they both come from the same server.
-FROM openjdk:11-jdk
+FROM adoptopenjdk:11-jdk
 
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends libxml2-utils && \
     rm -rf /var/cache/apt
 
-RUN wget -q http://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/maven.tar.gz && \
+RUN wget -q https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -O /tmp/maven.tar.gz && \
     mkdir -p /usr/local/lib/maven && \
     tar xzf /tmp/maven.tar.gz -C /usr/local/lib/maven --strip-components=1 && \
     rm /tmp/maven.tar.gz && \

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This appears to be from a newer source than AdoptOpenJDK
-FROM openjdk:8-jdk
+FROM adoptopenjdk:8-jdk
 
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends libxml2-utils && \
     rm -rf /var/cache/apt
 
-RUN wget -q http://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/maven.tar.gz && \
+RUN wget -q https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -O /tmp/maven.tar.gz && \
     mkdir -p /usr/local/lib/maven && \
     tar xzf /tmp/maven.tar.gz -C /usr/local/lib/maven --strip-components=1 && \
     rm /tmp/maven.tar.gz && \

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -19,13 +19,13 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libxml2-utils && \
     rm -rf /var/cache/apt
 
-RUN wget -q https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -O /tmp/maven.tar.gz && \
+RUN curl -sS https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -o /tmp/maven.tar.gz && \
     mkdir -p /usr/local/lib/maven && \
     tar xzf /tmp/maven.tar.gz -C /usr/local/lib/maven --strip-components=1 && \
     rm /tmp/maven.tar.gz && \
     ln -s $JAVA_HOME/lib $JAVA_HOME/conf
 
-RUN wget -q https://services.gradle.org/distributions/gradle-6.9-bin.zip -O /tmp/gradle.zip && \
+RUN curl -sS https://services.gradle.org/distributions/gradle-6.9-bin.zip -o /tmp/gradle.zip && \
     mkdir -p /usr/local/lib/gradle && \
     unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
     rm /tmp/gradle.zip
@@ -38,7 +38,7 @@ RUN mkdir -p /usr/local/gcloud && \
 
 # Install google-play-services version 1
 RUN mkdir -p /tmp/playservices && \
-    wget -q https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -O /tmp/play-services-basement.aar && \
+    curl -sS https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -o /tmp/play-services-basement.aar && \
     unzip -q /tmp/play-services-basement.aar -d /tmp/playservices && \
     mvn install:install-file \
         -Dfile=/tmp/playservices/classes.jar \
@@ -71,7 +71,6 @@ RUN pyenv install 3.6.12 && \
     pyenv global 3.6.12 && \
     python3 -m pip install --upgrade pip setuptools
 
-# Install docker
 # Install docker
 RUN apt-get update && apt-get install -y \
         apt-transport-https \

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This appears to be from a newer source than AdoptOpenJDK
 FROM openjdk:8-jdk
 
 RUN apt-get update && \
@@ -25,12 +26,12 @@ RUN wget -q http://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-ma
     rm /tmp/maven.tar.gz && \
     ln -s $JAVA_HOME/lib $JAVA_HOME/conf
 
-RUN wget -q https://services.gradle.org/distributions/gradle-4.9-bin.zip -O /tmp/gradle.zip && \
+RUN wget -q https://services.gradle.org/distributions/gradle-6.9-bin.zip -O /tmp/gradle.zip && \
     mkdir -p /usr/local/lib/gradle && \
     unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
     rm /tmp/gradle.zip
 
-ENV PATH $PATH:/usr/local/lib/maven/bin:/usr/local/lib/gradle/gradle-4.9/bin
+ENV PATH $PATH:/usr/local/lib/maven/bin:/usr/local/lib/gradle/gradle-6.9/bin
 
 # Install gcloud SDK
 RUN mkdir -p /usr/local/gcloud && \
@@ -48,7 +49,7 @@ RUN mkdir -p /tmp/playservices && \
         -Dpackaging=jar
 
 # Install the appengine SDK
-RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65
+RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.90
 
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -74,7 +74,7 @@ RUN pyenv install 3.6.12 && \
 # Install docker
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        "deb [arch=amd64] https://download.docker.com/linux/debian/dists/buster/ \
         $(lsb_release -cs) \
         stable" && \
     apt-get update && \

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -16,8 +16,12 @@ FROM adoptopenjdk:8-jdk
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends libxml2-utils && \
-    rm -rf /var/cache/apt
+    apt-get install -y libxml2-utils make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl graphviz imagemagick unzip \
+    apt-transport-https ca-certificates gnupg-agent lsb-release software-properties-common && \
+    rm -rf /var/cache/apt && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -o /tmp/maven.tar.gz && \
     mkdir -p /usr/local/lib/maven && \
@@ -54,13 +58,9 @@ RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install pyenv
-RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
-    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
-ENV PATH /root/.pyenv/bin:$PATH
-ENV PATH /root/.pyenv/shims:$PATH
+ENV PATH /root/.pyenv/shims:/root/.pyenv/bin:$PATH
 
 RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
@@ -72,14 +72,7 @@ RUN pyenv install 3.6.12 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Install docker
-RUN apt-get update && apt-get install -y \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg-agent \
-        lsb-release \
-        software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
         "deb [arch=amd64] https://download.docker.com/linux/debian \
         $(lsb_release -cs) \

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -23,13 +23,13 @@ RUN apt-get update && \
     rm -rf /var/cache/apt && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sS https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -o /tmp/maven.tar.gz && \
+RUN curl -sSL https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz -o /tmp/maven.tar.gz && \
     mkdir -p /usr/local/lib/maven && \
     tar xzf /tmp/maven.tar.gz -C /usr/local/lib/maven --strip-components=1 && \
     rm /tmp/maven.tar.gz && \
     ln -s $JAVA_HOME/lib $JAVA_HOME/conf
 
-RUN curl -sS https://services.gradle.org/distributions/gradle-6.9-bin.zip -o /tmp/gradle.zip && \
+RUN curl -sSL https://services.gradle.org/distributions/gradle-6.9-bin.zip -o /tmp/gradle.zip && \
     mkdir -p /usr/local/lib/gradle && \
     unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
     rm /tmp/gradle.zip
@@ -42,7 +42,7 @@ RUN mkdir -p /usr/local/gcloud && \
 
 # Install google-play-services version 1
 RUN mkdir -p /tmp/playservices && \
-    curl -sS https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -o /tmp/play-services-basement.aar && \
+    curl -sSL https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -o /tmp/play-services-basement.aar && \
     unzip -q /tmp/play-services-basement.aar -d /tmp/playservices && \
     mvn install:install-file \
         -Dfile=/tmp/playservices/classes.jar \

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y libxml2-utils make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl graphviz imagemagick unzip \
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl graphviz imagemagick unzip git \
     apt-transport-https ca-certificates gnupg-agent lsb-release software-properties-common && \
     rm -rf /var/cache/apt && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
* Upgrade Gradle to 6.9
* Confirm that OpenJDK is a newer source than AdoptOpenJDK - we may still want to move to it.
* upgrade App Engine SDK to 1.9.90