### PR TITLE
fix(java): fix Java Dockerfile build issues

### DIFF
--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
     rm -rf /var/cache/apt
 
-RUN wget -q https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip -O /tmp/maven.zip && \
+RUN wget -q https://archive.apache.org/dist/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip -O /tmp/maven.zip && \
     unzip /tmp/maven.zip -d /tmp/maven && \
     mv /tmp/maven/apache-maven-3.8.1 /usr/local/lib/maven && \
     rm /tmp/maven.zip && \
@@ -57,7 +57,7 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 # Install pyenv
 RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
 ENV PATH /root/.pyenv/bin:$PATH

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
     rm -rf /var/cache/apt
 
-RUN wget -q https://mirrors.advancedhosters.com/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip -O /tmp/maven.zip && \
+RUN wget -q https://archive.apache.org/dist/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip -O /tmp/maven.zip && \
     unzip /tmp/maven.zip -d /tmp/maven && \
     mv /tmp/maven/apache-maven-3.8.1 /usr/local/lib/maven && \
     rm /tmp/maven.zip && \
@@ -57,7 +57,7 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 # Install pyenv
 RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
 ENV PATH /root/.pyenv/bin:$PATH


### PR DESCRIPTION
This PR fixes java dockerfile build issues:

1. Use working Maven mirror for `3.8.1`.
2. Fix `python-openssl` package to `python3-openssl` which is the correct wrapper for python 3; `python-openssl` does not seem to be present in the default apt repositories:

```
---> Running in a5fefb3b4211
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python-openssl
```