### PR TITLE
fix(python): ensure pip for python 3.10

### DIFF
--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -163,8 +163,8 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
   # https://github.com/docker-library/python/pull/100
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
-# Ensure Pip for 3.9
-RUN python3.9 /tmp/get-pip.py
+# Ensure Pip for 3.10
+RUN python3.10 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
 
 # Test Pip

--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -163,8 +163,8 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
   # https://github.com/docker-library/python/pull/100
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
-# Ensure Pip for 3.10
-RUN python3.10 /tmp/get-pip.py
+# Ensure Pip for 3.9
+RUN python3.9 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
 
 # Test Pip

--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -163,9 +163,12 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
   # https://github.com/docker-library/python/pull/100
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
-# Ensure Pip for 3.9
-RUN python3.9 /tmp/get-pip.py
+# Ensure Pip for 3.10
+RUN python3.10 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
+
+# Test Pip
+RUN python3 -m pip
 
 # Install "virtualenv", since the vast majority of users of this image
 # will want it.


### PR DESCRIPTION
This PR fixes the issue where `python3 -m pip` results in `/usr/local/bin/python3: No module named pip` in `gcr.io/cloud-devrel-kokoro-resources/python-multi`.

Steps to reproduce:
Run
```
docker run --rm -it --entrypoint /bin/bash gcr.io/cloud-devrel-kokoro-resources/python-multi:py3.10-missing-pip
```

In the container, run
```
python3 -m pip
```

which results in the following error: 
```
/usr/local/bin/python3: No module named pip
```
