### PR TITLE
feat: add php container which contains all currently supported versions

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -2,7 +2,8 @@
 > The docker images for running PHP Kokoro builds for Cloud repositories.
 
 ## Docker Registry
-This image is available at `gcr.io/cloud-devrel-kokoro-resources/php##`.  You can try it out by running:
+The images for individual versions of PHP are available at `gcr.io/cloud-devrel-kokoro-resources/php##`.
+You can try them out by running:
 
 ```sh
 $ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php72
@@ -10,6 +11,23 @@ $ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php73
 $ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php74
 $ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php80
 ```
+
+An image containing all [supported versions][php-version-support] of PHP is available
+at `gcr.io/cloud-devrel-kokoro-resources/php`. You can try it out by running"
+
+```sh
+$ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php
+```
+
+When using the image, switching between versions of PHP is done using [PHPBrew][phpbrew]:
+
+```sh
+# Switch to PHP 8.0
+phpbrew switch $(phpbrew list | grep 8.0)
+```
+
+[php-version-support]: https://www.php.net/supported-versions.php
+[phpbrew]: https://github.com/phpbrew/phpbrew
 
 ## Questions
 Please reach out to `php-cloud@google.com` with any questions!

--- a/php/cloudbuild-test.yaml
+++ b/php/cloudbuild-test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 14400s  # 4 hours
+timeout: 18000s  # 5 hours
 steps:
 
 # PHP 7.2
@@ -37,4 +37,10 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php80', '.']
   dir: 'php/php80'
+  waitFor: ['-']
+
+# PHP 7.3 / 7.4 / 8.0
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php', '.']
+  dir: 'php/php'
   waitFor: ['-']

--- a/php/cloudbuild-test.yaml
+++ b/php/cloudbuild-test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 21600s  # 6 hours
+timeout: 28800s  # 6 hours
 steps:
 
 # PHP 7.2

--- a/php/cloudbuild-test.yaml
+++ b/php/cloudbuild-test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 18000s  # 5 hours
+timeout: 21600s  # 6 hours
 steps:
 
 # PHP 7.2

--- a/php/cloudbuild.yaml
+++ b/php/cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 18000s  # 5 hours
+timeout: 21600s  # 6 hours
 steps:
 
 # PHP 7.2

--- a/php/cloudbuild.yaml
+++ b/php/cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 14400s  # 4 hours
+timeout: 18000s  # 5 hours
 steps:
 
 # PHP 7.2
@@ -39,8 +39,15 @@ steps:
   dir: 'php/php80'
   waitFor: ['-']
 
+# PHP 7.3 / 7.4 / 8.0
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php', '.']
+  dir: 'php/php'
+  waitFor: ['-']
+
 images:
   - gcr.io/cloud-devrel-kokoro-resources/php72
   - gcr.io/cloud-devrel-kokoro-resources/php73
   - gcr.io/cloud-devrel-kokoro-resources/php74
   - gcr.io/cloud-devrel-kokoro-resources/php80
+  - gcr.io/cloud-devrel-kokoro-resources/php

--- a/php/php/Dockerfile
+++ b/php/php/Dockerfile
@@ -1,0 +1,117 @@
+FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
+
+ENV PHPBREW_ROOT /root/.phpbrew
+ENV PHPBREW_HOME /root/.phpbrew
+ENV PHPBREW_SET_PROMPT 1
+
+# ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update \
+  && apt-get -qqy install git \
+  && apt-get -qqy install wget \
+  && apt-get -qqy install curl \
+  && apt-get -qqy install ant ant-contrib sqlite3 \
+  && apt-get -qqy install \
+      autoconf \
+      build-essential \
+      libbz2-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      libxml2-dev \
+      libxslt1-dev \
+      libonig-dev \
+      php7.2-cli \
+      php7.2-bz2 \
+      pkg-config \
+      libcurl4-gnutls-dev \
+      libzip-dev zip \
+      libmagickwand-dev \
+      php-imagick \
+      jq \
+  && apt-get clean -y \
+  && apt-get autoclean -y \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/{apt,dpkg,cache,log}/ \
+  && rm -rf /var/lib/apt/lists/*
+
+# Use a better shell
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Install and initialize PHPBrew
+RUN mkdir -p /usr/bin/ \
+    && wget -q -O /usr/bin/phpbrew https://github.com/phpbrew/phpbrew/raw/master/phpbrew \
+    && chmod +x /usr/bin/phpbrew \
+    && phpbrew init \
+    && echo 'source $HOME/.phpbrew/bashrc' >> /root/.bashrc
+
+# Install PHP 7.3
+RUN phpbrew install "7.3" \
+    +default +bcmath +bz2 +calendar +cli +ctype +dom +fileinfo +filter +json \
+    +mbregex +mbstring +mhash +pcntl +pcre +pdo +phar +posix +readline +sockets \
+    +tokenizer +xml +curl +zip +openssl=yes +opcache +fpm +sqlite +mysql \
+    +default +intl +gettext
+
+# Install PHP 7.4
+RUN phpbrew install "7.4" \
+    +default +bcmath +bz2 +calendar +cli +ctype +dom +fileinfo +filter +json \
+    +mbregex +mbstring +mhash +pcntl +pcre +pdo +phar +posix +readline +sockets \
+    +tokenizer +xml +curl +zip +openssl=yes +opcache +fpm +sqlite +mysql \
+    +default +intl +gettext
+
+# Install PHP 8.0
+RUN phpbrew install "8.0" \
+    +default +bcmath +bz2 +calendar +cli +ctype +dom +fileinfo +filter +json \
+    +mbregex +mbstring +mhash +pcntl +pcre +pdo +phar +posix +readline +sockets \
+    +tokenizer +xml +curl +zip +openssl=yes +opcache +fpm +sqlite +mysql \
+    +default +intl +gettext
+
+# Install and enable Imagemagick extension for PHP 7.3, 7.4, and 8.0
+RUN source ~/.phpbrew/bashrc \
+    && phpbrew switch $(phpbrew list | grep 7.3) && phpbrew ext install imagick \
+    && phpbrew switch $(phpbrew list | grep 7.4) && phpbrew ext install imagick \
+    # On PHP 8.0, Imagemagick must be compiled from src because it is not yet
+    # available via PECL
+    && phpbrew switch $(phpbrew list | grep 8.0) \
+        && git clone https://github.com/Imagick/imagick /tmp/imagick \
+        && cd /tmp/imagick \
+        && phpize \
+        && ./configure \
+        && make \
+        && make install \
+        && phpbrew ext enable imagick
+
+# Install and enable gRPC/memcache/opcache extensions for PHP 7.3, 7.4, and 8.0
+RUN source ~/.phpbrew/bashrc \
+    && phpbrew each phpbrew ext install grpc \
+    && phpbrew each phpbrew ext install memcache \
+    && phpbrew each phpbrew ext enable opcache
+
+# Install composer
+RUN wget -q -O /usr/bin/composer https://getcomposer.org/composer.phar && chmod +x /usr/bin/composer
+
+# Install Google Cloud SDK
+RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz \
+        -o ${HOME}/google-cloud-sdk.tar.gz \
+    && tar xzf ${HOME}/google-cloud-sdk.tar.gz -C $HOME \
+    && ${HOME}/google-cloud-sdk/install.sh \
+        --usage-reporting false \
+        --path-update false \
+        --command-completion false \
+    && source ${HOME}/google-cloud-sdk/path.bash.inc
+
+# Install Cloud SQL proxy
+RUN wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy \
+    && chmod +x cloud_sql_proxy \
+    && mv cloud_sql_proxy /usr/local/bin
+
+# Make composer and gcloud bins available via the PATH variable
+ENV PATH="$PATH:/root/.config/composer/vendor/bin:/root/google-cloud-sdk/bin"
+
+# Configure Google Cloud SDK
+RUN gcloud config set app/promote_by_default false && \
+    gcloud config set disable_prompts true && \
+    gcloud -q components install app-engine-python && \
+    gcloud -q components update
+
+# Install php-cs-fixer
+RUN composer global require friendsofphp/php-cs-fixer


### PR DESCRIPTION
For improved testing in PHP samples, we want to use one container which allows switching between PHP versions. This will allow the following improvements:

### Improvements

 1. The samples can run in parallel for each sample directory, instead of for each PHP version. This means each kokoro instance will run This should speed up running tests significantly, as the time to run the tests of the longest sample directory 3 times should be less than the time required to run the entire sample suite.
 2. We currently use 7 different Cloud Projects to run our tests: Each of the three supported versions of PHP we test on require one Cloud Project for firestore and one for datastore, plus one default Cloud Project. This is required to avoid race conditions. With this change, we will only need 2 Cloud Projects total, one for Firestore and one for Datastore.
 3. It will be easier to add a fourth version of PHP in the future. Currently we are limited to only running tests on 3 versions of PHP, without setting up two additional projects.

### Considerations

1. Our longest sample tests take ~15 minutes (spanner), so running this on 4 versions of PHP could take over an hour. We can consider refactoring the tests to [run in parallel](https://github.com/paratestphp/paratest) per PHP version, or even for each PHP version in the same container, if these bottlenecks become severe.
2. We will probably run into quota limits and other unexpected errors when we first move to only two projects. This may be difficult to resolve, but  will ultimately be worth the pain.
3. We can add a catch-all container for all the directories with samples which don't have a `[sample-dir].conf`. That way, when a new sample directory is added, it will still get tested, and we can split samples out into their own directories as needed.

See also: https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1394
cc @saranshdhingra 