### PR TITLE
deps: upgrading GraalVM version to 21.3

### DIFF
--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.2.0
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3
 
 RUN gu install native-image && \
     yum update -y && \


### PR DESCRIPTION
Corresponding upgrade in native-image-support-java: https://github.com/GoogleCloudPlatform/native-image-support-java/pull/249