### PR TITLE
fix(go): fix go dockerfile build issues

### DIFF
--- a/go/go113/Dockerfile
+++ b/go/go113/Dockerfile
@@ -31,7 +31,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@latest && \
-    go get github.com/jstemmer/go-junit-report@latest
+RUN GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@latest
+RUN GO111MODULE=on go get github.com/jstemmer/go-junit-report@latest
 
 WORKDIR $GOPATH

--- a/go/go114/Dockerfile
+++ b/go/go114/Dockerfile
@@ -31,7 +31,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@latest && \
-    go get github.com/jstemmer/go-junit-report@latest
+RUN GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@latest
+RUN GO111MODULE=on go get github.com/jstemmer/go-junit-report@latest
 
 WORKDIR $GOPATH

--- a/go/go115/Dockerfile
+++ b/go/go115/Dockerfile
@@ -62,7 +62,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@latest && \
-    go get github.com/jstemmer/go-junit-report@latest
+RUN GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@latest
+RUN GO111MODULE=on go get github.com/jstemmer/go-junit-report@latest
 
 WORKDIR $GOPATH

--- a/go/go116/Dockerfile
+++ b/go/go116/Dockerfile
@@ -18,6 +18,7 @@ FROM golang:1.16
 RUN set -ex; \
     apt-get update -y; \
     apt-get install -y \
+    apt-get upgrade python-openssl \
     make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python-openssl \

--- a/go/go116/Dockerfile
+++ b/go/go116/Dockerfile
@@ -18,10 +18,9 @@ FROM golang:1.16
 RUN set -ex; \
     apt-get update -y; \
     apt-get install -y \
-    apt-get upgrade python-openssl \
     make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl \
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl \
     apt-transport-https ca-certificates gnupg curl gnupg-agent lsb-release software-properties-common \
     unzip wget vim; \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fix go dockerfile build issues [(1)](https://pantheon.corp.google.com/cloud-build/builds;region=global/b8a0eb35-83de-490d-b59e-be11f8554946;step=10?project=cloud-devrel-kokoro-resources)[(2)](https://pantheon.corp.google.com/cloud-build/builds/fc284550-9a51-4909-82c7-3bd1fdf5b898;step=4?project=cloud-devrel-kokoro-resources)
- update `python-openssl` to `python3-openssl` in go116
- revise go113, go114, go115 dockerfile commands

```
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python-openssl
```

```
go: cannot use path@version syntax in GOPATH mode
The command '/bin/sh -c GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@latest &&     go get github.com/jstemmer/go-junit-report@latest' returned a non-zero code: 1
```