### PR TITLE
fix: upgrade GraalVM version to 22.0.0

### DIFF
--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.0
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.1
 
 RUN gu install native-image && \
     yum update -y && \

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.1
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-22.0.0.2
 
 RUN gu install native-image && \
     yum update -y && \

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.2.0
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.0
 
 RUN gu install native-image && \
     yum update -y && \


### PR DESCRIPTION
This PR upgrades the GraalVM version 22.0.02 (the latest). 

The latest version of the native-maven-plugin (0.9.11) which is used to run tests with native image support is incompatible with GraalVM 21.2.0. As a result, we're running into the following error in all our repos:
```
[org.graalvm.junit.platform.NativeImageJUnitLauncher:950181]    classlist:     862.05 ms,  0.96 GB
Error: Main entry point class '@/tmp/native-image6785363509462544469args' not found.
Error: Use -H:+ReportExceptionStackTraces to print stacktrace of underlying exception
```
Reproducer: https://github.com/mpeddada1/native-image-args 

cc @meltsufin 