### PR TITLE
fix: install docker on Native Image testing Kokoro image

### DIFF
--- a/java/graalvm.yaml
+++ b/java/graalvm.yaml
@@ -27,3 +27,6 @@ commandTests:
   - name: "gcloud"
     command: ["gcloud", "version"]
     expectedOutput: ["Google Cloud SDK"]
+  - name: "docker"
+    command: ["docker", "--version"]
+    expectedOutput: ["Docker version *"]

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -39,6 +39,6 @@ RUN yum install -y google-cloud-sdk
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install docker
-RUN yum install docker-engine docker-cli
+RUN yum install -y docker-engine docker-cli
 
 WORKDIR /workspace

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -39,7 +39,6 @@ RUN yum install -y google-cloud-sdk
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install docker
-RUN docker --version
 RUN yum install -y docker-engine docker-cli
 
 WORKDIR /workspace

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -39,19 +39,6 @@ RUN yum install -y google-cloud-sdk
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install docker
-RUN apt-get update && apt-get install -y \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg-agent \
-        lsb-release \
-        software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/debian \
-        $(lsb_release -cs) \
-        stable" && \
-    apt-get update && \
-    apt-get install -y docker-ce docker-ce-cli containerd.io
+RUN yum install docker-engine docker-cli
 
 WORKDIR /workspace

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -38,4 +38,21 @@ RUN yum install -y google-cloud-sdk
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
+# Install docker
+# Install docker
+RUN apt-get update && apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        lsb-release \
+        software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
 WORKDIR /workspace

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -39,7 +39,6 @@ RUN yum install -y google-cloud-sdk
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install docker
-# Install docker
 RUN apt-get update && apt-get install -y \
         apt-transport-https \
         ca-certificates \

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -39,6 +39,7 @@ RUN yum install -y google-cloud-sdk
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install docker
+RUN docker --version
 RUN yum install -y docker-engine docker-cli
 
 WORKDIR /workspace


### PR DESCRIPTION
Storage tests require docker to be installed and on $PATH, otherwise the result in the following error

```
java.io.IOException: Cannot run program "docker": error=2, No such file or directory
Caused by: java.io.IOException: error=2, No such file or directory
```