### PR TITLE
fix: use GraalVM 21.3.2

### DIFF
--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-21.3.2-b1
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.3.2-b1
 
 RUN gu install native-image && \
     yum update -y && \

--- a/java/graalvm/Dockerfile
+++ b/java/graalvm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-22.0.0.2
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-21.3.2-b1
 
 RUN gu install native-image && \
     yum update -y && \


### PR DESCRIPTION
Downgrading to 21.3.2 to address CVE https://security.snyk.io/vuln/SNYK-JAVA-ORGGRAALVMSDK-2769618. We can't upgrade the version to 22.1.0 as the graal-sdk 21.3.2 (which is being used by the project poms as of https://github.com/googleapis/gax-java/pull/1670) is incompatible with it. See reproducible example here: https://github.com/mpeddada1/check-22.1. 