### PR TITLE
feat: Update Java 17 image with sample dependencies

### DIFF
--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -75,6 +75,16 @@ RUN pyenv install 3.6.12 && \
     pyenv global 3.6.12 && \
     python3 -m pip install --upgrade pip setuptools
 
+# Add Graphviz for Cloud Run samples
+RUN apt-get update -y && \
+    apt-get install -y graphviz && \
+    rm -rf /var/lib/apt/lists/*
+    
+# Add imagemagick for Cloud Run samples
+RUN apt-get update -y && \
+    apt-get install -y imagemagick && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install docker
 RUN apt-get update && apt-get install -y \
         apt-transport-https \


### PR DESCRIPTION
This mimics the Java 11 image:
https://github.com/googleapis/testing-infra-docker/blob/c186d708c19c3b3bcfd2a0d4c9f85bc4a7b832cf/java/java11/Dockerfile#L75-L83