### PR TITLE
deps: adding JDK 11 as the supplement to java8 container

### DIFF
--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -87,4 +87,12 @@ RUN apt-get update && apt-get install -y \
         stable" && \
     apt-get update && \
     apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Installing JDK 11 to build projects that depend on graal-sdk 22.1.0 or higher
+# (requiring Java 11+). Still we target Java 8 for the compiled class files.
+RUN apt-get install -y openjdk-11-jdk
+# JDK 11 is used only when explicitly selected in the build file
+ENV JAVA8_HOME=/usr/local/openjdk-8
+ENV JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
 WORKDIR /workspace


### PR DESCRIPTION
This change enables us to build a project in JDK 11 and run tests in JDK 8 runtime.

How I confirmed the updated Docker file:

```
suztomo@suztomo:~/testing-infra-docker/java/java8$ docker build .
Sending build context to Docker daemon  6.144kB
Step 1/20 : FROM openjdk:8-jdk
 ---> c43167b660ad
...
Step 20/20 : WORKDIR /workspace
 ---> Running in 949d7b16df43
Removing intermediate container 949d7b16df43
 ---> 890bb1639e37
Successfully built 890bb1639e37
suztomo@suztomo:~/testing-infra-docker/java/java8$ docker run --rm -it --entrypoint bash 890bb1639e37
root@d2439762fd1a:/workspace# printenv
PYENV_SHELL=bash
HOSTNAME=d2439762fd1a
JAVA_HOME=/usr/local/openjdk-8
JAVA8_HOME=/usr/local/openjdk-8
PWD=/workspace
HOME=/root
LANG=C.UTF-8
JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
TERM=xterm
SHLVL=1
PATH=/root/.pyenv/shims:/root/.pyenv/bin:/usr/local/openjdk-8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/lib/maven/bin:/usr/local/lib/gradle/gradle-4.9/bin:/usr/local/gcloud/google-cloud-sdk/bin
JAVA_VERSION=8u332
_=/usr/bin/printenv
root@d2439762fd1a:/workspace# ${JAVA8_HOME}/bin/javac -version
javac 1.8.0_332
root@d2439762fd1a:/workspace# ${JAVA11_HOME}/bin/javac -version
javac 11.0.15
root@d2439762fd1a:/workspace# ^C
```

- The image continue to use Java 8 as default JDK (See `JAVA_HOME=/usr/local/openjdk-8` in the output above)
- The generated image provides environment variables `JAVA8_HOME` and `JAVA11_HOME` for [`build.sh`](https://github.com/googleapis/java-spanner/pull/1870/files#diff-6ec64aad727811781a78bc1dd7e4fd68ac708ccff197213425ae5933df4f0a49R33).
