### PR TITLE
fix: bump php memory limit

### DIFF
--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
 
 # install / enable PHP extensions
 RUN pecl install grpc \
+    && sed -i 's/memory_limit = .*/memory_limit = 256M/' /opt/php72/lib/php.ini \
     && echo "extension=grpc.so" >> /opt/php72/lib/conf.d/ext-grpc.ini \
     && echo "extension=bcmath.so" >> /opt/php72/lib/conf.d/ext-bcmath.ini \
     && echo "extension=imagick.so" >> /opt/php72/lib/conf.d/ext-imagick.ini

--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
 
 # install / enable PHP extensions
 RUN pecl install grpc \
-    && sed -i 's/memory_limit = .*/memory_limit = 256M/' /opt/php72/lib/php.ini \
     && echo "extension=grpc.so" >> /opt/php72/lib/conf.d/ext-grpc.ini \
     && echo "extension=bcmath.so" >> /opt/php72/lib/conf.d/ext-bcmath.ini \
     && echo "extension=imagick.so" >> /opt/php72/lib/conf.d/ext-imagick.ini

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -95,7 +95,7 @@ RUN ln -s /usr/lib/libc-client.a /usr/lib/x86_64-linux-gnu/libc-client.a && \
         make install && \
         pecl install grpc imagick pdo_sqlsrv && \
         cp php.ini-production ${PHP_DIR}/lib/php.ini && \
-        sed -i 's/memory_limit = .*/memory_limit = 256M/' ${PHP_DIR}/lib/php.ini && \
+        sed -i 's/memory_limit = 128M/memory_limit = -1/' ${PHP_DIR}/lib/php.ini && \
         echo 'zend_extension=opcache.so' >> ${PHP_DIR}/lib/php.ini && \
         echo 'extension=grpc.so' >> ${PHP_DIR}/lib/conf.d/ext-grpc.ini && \
         echo 'extension=imagick.so' >> ${PHP_DIR}/lib/conf.d/ext-imagick.ini && \

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -95,7 +95,7 @@ RUN ln -s /usr/lib/libc-client.a /usr/lib/x86_64-linux-gnu/libc-client.a && \
         make install && \
         pecl install grpc imagick pdo_sqlsrv && \
         cp php.ini-production ${PHP_DIR}/lib/php.ini && \
-        sed -i 's/memory_limit = 128M/mempory_limit = -1/' ${PHP_DIR}/lib/php.ini && \
+        sed -i 's/memory_limit = .*/memory_limit = 256M/' ${PHP_DIR}/lib/php.ini && \
         echo 'zend_extension=opcache.so' >> ${PHP_DIR}/lib/php.ini && \
         echo 'extension=grpc.so' >> ${PHP_DIR}/lib/conf.d/ext-grpc.ini && \
         echo 'extension=imagick.so' >> ${PHP_DIR}/lib/conf.d/ext-imagick.ini && \

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -94,6 +94,7 @@ RUN ln -s /usr/lib/libc-client.a /usr/lib/x86_64-linux-gnu/libc-client.a && \
         make install && \
         pecl install grpc imagick pdo_sqlsrv && \
         cp php.ini-production ${PHP_DIR}/lib/php.ini && \
+        sed -i 's/memory_limit = .*/memory_limit = 256M/' ${PHP_DIR}/lib/php.ini && \
         echo 'zend_extension=opcache.so' >> ${PHP_DIR}/lib/php.ini && \
         echo 'extension=grpc.so' >> ${PHP_DIR}/lib/conf.d/ext-grpc.ini && \
         echo 'extension=imagick.so' >> ${PHP_DIR}/lib/conf.d/ext-imagick.ini && \

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -94,6 +94,7 @@ RUN ln -s /usr/lib/libc-client.a /usr/lib/x86_64-linux-gnu/libc-client.a && \
         make install && \
         pecl install grpc pdo_sqlsrv && \
         cp php.ini-production ${PHP_DIR}/lib/php.ini && \
+        sed -i 's/memory_limit = .*/memory_limit = 256M/' ${PHP_DIR}/lib/php.ini && \
         echo 'zend_extension=opcache.so' >> ${PHP_DIR}/lib/php.ini && \
         echo 'extension=grpc.so' >> ${PHP_DIR}/lib/conf.d/ext-grpc.ini && \
         git clone https://github.com/Imagick/imagick /tmp/imagick && cd /tmp/imagick && phpize && ./configure && make && make install && cd - && \


### PR DESCRIPTION
Fixes https://github.com/googleapis/testing-infra-docker/issues/249

Once the `google-cloud-php` build is green, I will update the `Dockerfile` in other PHP versions.