### PR TITLE
chore: Upgrade to Python 3.9.13 for all Java Containers

### DIFF
--- a/java/java11.yaml
+++ b/java/java11.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.11.0"]
+  expectedOutput: ["Python 3.9.13"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java11.yaml
+++ b/java/java11.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.6.12"]
+  expectedOutput: ["Python 3.11.0"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -68,8 +68,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.12 && \
-    pyenv global 3.6.12 && \
+RUN pyenv install 3.11.0 && \
+    pyenv global 3.11.0 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Add Graphviz

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -68,8 +68,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.11.0 && \
-    pyenv global 3.11.0 && \
+RUN pyenv install 3.9.13 && \
+    pyenv global 3.9.13 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Add Graphviz

--- a/java/java17.yaml
+++ b/java/java17.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.11.0"]
+  expectedOutput: ["Python 3.9.13"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java17.yaml
+++ b/java/java17.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.6.12"]
+  expectedOutput: ["Python 3.11.0"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -71,8 +71,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.12 && \
-    pyenv global 3.6.12 && \
+RUN pyenv install 3.11.0 && \
+    pyenv global 3.11.0 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Add Graphviz for Cloud Run samples

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -71,8 +71,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.11.0 && \
-    pyenv global 3.11.0 && \
+RUN pyenv install 3.9.13 && \
+    pyenv global 3.9.13 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Add Graphviz for Cloud Run samples

--- a/java/java8.yaml
+++ b/java/java8.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.11.0"]
+  expectedOutput: ["Python 3.9.13"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java8.yaml
+++ b/java/java8.yaml
@@ -38,7 +38,7 @@ commandTests:
   expectedError: ["using libxml version"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.6.12"]
+  expectedOutput: ["Python 3.11.0"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -68,8 +68,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.6.12 && \
-    pyenv global 3.6.12 && \
+RUN pyenv install 3.11.0 && \
+    pyenv global 3.11.0 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Install docker

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -68,8 +68,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
     echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
 
 # Install python
-RUN pyenv install 3.11.0 && \
-    pyenv global 3.11.0 && \
+RUN pyenv install 3.9.13 && \
+    pyenv global 3.9.13 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Install docker


### PR DESCRIPTION
[WIP]

I'm not sure if there is any historical reason why we're using python v3.6.x. Opening a draft PR to start a discussion to migrate/ upgrade the current python version `v3.6.x` to a non-EOL python version `v3.7.x+`. I'd like to aim for at least Python `v3.9.13`
- Info via https://devguide.python.org/versions/

Issues with Python v3.6.x:
- It has reached EOL almost a year ago
- gcp-docuploader (https://github.com/googleapis/docuploader) has to be pinned at v0.6.3 (docuploader v0.6.4+ has dependencies that aren't compatible with Python v3.6.x).

Confirmation before release:
Logs:
Owl-bot: https://github.com/googleapis/testing-infra-docker/pull/260#issuecomment-1358329724
GCP-DocUploader:
```
lawrenceqiu@lawrenceqiu:~/IdeaProjects/google-cloud-java$ python3 --version
Python 3.9.0
lawrenceqiu@lawrenceqiu:~/IdeaProjects/google-cloud-java$     python3 -m docuploader create-metadata       --name test       --version 0.1       --language java
docuploader > Wrote metadata to docs.metadata.
lawrenceqiu@lawrenceqiu:~/IdeaProjects/google-cloud-java$ 
```

To confirm after release:
- Java containers are able to run integration tests 
- Java 8 and 17 containers are able to run GraalVM tests
- Java 8, 11, 17 containers are able to run gcp-docuploader