### PR TITLE
fix(java): ensure that renovate-bot picks up graalvm-ce docker image tag

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     {
       "fileMatch": ["^java/cloudbuild.yaml", "^java/cloudbuild-test.yaml"],
       "matchStrings": ["  _GRAALVM_VERSION: '(?<currentValue>.*?)'"],
-      "depNameTemplate": "ghcr.io/graalvm/jdk",
+      "depNameTemplate": "ghcr.io/graalvm/graalvm-ce",
       "datasourceTemplate": "docker"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,8 @@
     {
       "fileMatch": ["^java/cloudbuild.yaml", "^java/cloudbuild-test.yaml"],
       "matchStrings": ["  _GRAALVM_VERSION: '(?<currentValue>.*?)'"],
-      "depNameTemplate": "jdk",
-      "datasourceTemplate": "docker",
-      "packageNameTemplate": "ghcr.io/graalvm/jdk"
+      "depNameTemplate": "ghcr.io/graalvm/jdk",
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
GraalVM 22.3.1 has been released but a renovate-bot PR is yet to be created in this repository. 

From https://github.com/googleapis/testing-infra-docker/issues/162:

<img width="713" alt="Screenshot 2023-02-15 at 11 21 26 AM" src="https://user-images.githubusercontent.com/66699525/219088226-d305fa0f-293f-4fe7-9e4b-07d9d5040c8a.png">

This PR sets depNameTemplate to `ghcr.io/graalvm/graalvm-ce` instead of `jdk`. Tested with https://github.com/mpeddada1/renovate-bot-test/pull/12/files