### PR TITLE
build: add puppeteer-14 to test workflow

### DIFF
--- a/node/14-puppeteer/Dockerfile
+++ b/node/14-puppeteer/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 
+# Run everything after as non-privileged user.
+USER node
+
 # Setup Cloud SDK
 WORKDIR /home/node
 ENV CLOUD_SDK_VERSION=303.0.0 \
@@ -37,8 +40,5 @@ RUN set -ex; \
     gcloud config set component_manager/disable_update_check true; \
     gcloud --quiet components update; \
     gcloud --quiet components install beta
-
-# Run everything after as non-privileged user.
-USER node
 
 ENTRYPOINT ["dumb-init", "--"]

--- a/node/14-puppeteer/Dockerfile
+++ b/node/14-puppeteer/Dockerfile
@@ -22,9 +22,6 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 
-# Run everything after as non-privileged user.
-USER node
-
 # Setup Cloud SDK
 WORKDIR /home/node
 ENV CLOUD_SDK_VERSION=303.0.0 \
@@ -40,5 +37,8 @@ RUN set -ex; \
     gcloud config set component_manager/disable_update_check true; \
     gcloud --quiet components update; \
     gcloud --quiet components install beta
+
+# Run everything after as non-privileged user.
+USER node
 
 ENTRYPOINT ["dumb-init", "--"]

--- a/node/cloudbuild-test.yaml
+++ b/node/cloudbuild-test.yaml
@@ -38,3 +38,15 @@ steps:
   args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:14-user', '.']
   dir: 'node/14-user'
   waitFor: ['-']
+
+# Node 14-puppeteer
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:14-puppeteer', '.']
+  dir: 'node/14-puppeteer'
+  waitFor: ['-']
+
+# Node 16
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:16-user', '.']
+  dir: 'node/16-user'
+  waitFor: ['-']

--- a/node/cloudbuild.yaml
+++ b/node/cloudbuild.yaml
@@ -33,16 +33,16 @@ steps:
   dir: 'node/12-puppeteer'
   waitFor: ['-']
 
-# Node 14-puppeteer
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:14-puppeteer', '-t', 'gcr.io/cloud-devrel-public-resources/node:14-puppeteer', '.']
-  dir: 'node/14-puppeteer'
-  waitFor: ['-']
-
 # Node 14
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:14-user', '-t', 'gcr.io/cloud-devrel-public-resources/node:14-user', '.']
   dir: 'node/14-user'
+  waitFor: ['-']
+
+# Node 14-puppeteer
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:14-puppeteer', '-t', 'gcr.io/cloud-devrel-public-resources/node:14-puppeteer', '.']
+  dir: 'node/14-puppeteer'
   waitFor: ['-']
 
 # Node 16


### PR DESCRIPTION
Moving the Cloud SDK installation below setting the user, to match the `node14:user` Dockerfile flow.

This should address:
```
ERROR: (gcloud.components.update) You cannot perform this action because you do not have permission to modify the Google Cloud SDK installation directory [/home/node/google-cloud-sdk].
```