### PR TITLE
feat: updates approach to installing conda/mamba to use micromamba

### DIFF
--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -144,11 +144,12 @@ RUN for PYTHON_VERSION in 2.7.18 3.7.12 3.8.13 3.9.13 3.10.5 3.11.1; do \
   && rm -rf ~/.cache/ \
   && rm -r "$GNUPGHOME"
 
-# Install a version of conda/mamba package manager.
+# Install a version of conda/mamba package manager called micromamba.
 # This is used to help test conda installs of client libraries such as:
 # google-cloud-bigquery (python-bigquery)
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
-RUN bash Mambaforge-$(uname)-$(uname -m).sh -b
+
+RUN curl micro.mamba.pm/install.sh | bash
+RUN ~/.local/bin/micromamba shell init -s bash -p ~/micromamba
 
 # Install pip on Python 3.10 only.
 # If the environment variable is called "PIP_VERSION", pip explodes with


### PR DESCRIPTION
The previously used approach to installing mamba was not working as expected. During research, we found that there is a micro installer for mamba that takes up less space but still has the vast majority of features. 

This change installs micromamba and initializes it so that it should be available when the docker container loads.