### PR TITLE
fix: updates commandline refs to python3

### DIFF
--- a/python/cloud-devrel-kokoro-resources/python/Dockerfile
+++ b/python/cloud-devrel-kokoro-resources/python/Dockerfile
@@ -34,8 +34,8 @@ RUN apt update \
     zlib1g-dev \
  && apt clean
 
-RUN python --version
-RUN which python
+RUN python3 --version
+RUN which python3
 
 # Setup Cloud SDK
 ENV CLOUD_SDK_VERSION 420.0.0


### PR DESCRIPTION
Removal python 2.7 and solely requiring python 3 led to some failing tests.
Updates command line commands to accommodate.