### PR TITLE
build: use Debian buster for Node 16 image

### DIFF
--- a/node/10-user/Dockerfile
+++ b/node/10-user/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:10-stretch
+FROM node:10-buster
 
 # Add Graphviz
 RUN set -ex; \
@@ -66,8 +66,8 @@ RUN pyenv install 3.7.1 && \
 
 # Setup Cloud SDK
 WORKDIR /home/node
-ENV CLOUD_SDK_VERSION=261.0.0 \
-    CLOUDSDK_PYTHON=/usr/bin/python \
+ENV CLOUD_SDK_VERSION=438.0.0 \
+    CLOUDSDK_PYTHON=/usr/bin/python3 \
     PATH=/home/node/google-cloud-sdk/bin:$PATH
 RUN set -ex; \
     curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz; \

--- a/node/12-user/Dockerfile
+++ b/node/12-user/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:12-stretch
+FROM node:12-buster
 
 # Add Graphviz
 RUN set -ex; \
@@ -70,8 +70,8 @@ RUN python3 -m pip install --require-hashes -r requirements.txt
 
 # Setup Cloud SDK
 WORKDIR /home/node
-ENV CLOUD_SDK_VERSION=261.0.0 \
-    CLOUDSDK_PYTHON=/usr/bin/python \
+ENV CLOUD_SDK_VERSION=438.0.0 \
+    CLOUDSDK_PYTHON=/usr/bin/python3 \
     PATH=/home/node/google-cloud-sdk/bin:$PATH
 RUN set -ex; \
     curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz; \

--- a/node/14-puppeteer/Dockerfile
+++ b/node/14-puppeteer/Dockerfile
@@ -48,8 +48,8 @@ RUN pyenv install 3.7.4 && \
 
 # Setup Cloud SDK
 WORKDIR /home/node
-ENV CLOUD_SDK_VERSION=303.0.0 \
-    CLOUDSDK_PYTHON=/usr/bin/python \
+ENV CLOUD_SDK_VERSION=438.0.0 \
+    CLOUDSDK_PYTHON=/usr/bin/python3 \
     PATH=/home/node/google-cloud-sdk/bin:$PATH
 RUN set -ex; \
     curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz; \

--- a/node/14-user/Dockerfile
+++ b/node/14-user/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:14-stretch
+FROM node:14-buster
 
 # Add Graphviz
 RUN set -ex; \
@@ -70,8 +70,8 @@ RUN python3 -m pip install --require-hashes -r requirements.txt
 
 # Setup Cloud SDK
 WORKDIR /home/node
-ENV CLOUD_SDK_VERSION=303.0.0 \
-    CLOUDSDK_PYTHON=/usr/bin/python \
+ENV CLOUD_SDK_VERSION=438.0.0 \
+    CLOUDSDK_PYTHON=/usr/bin/python3 \
     PATH=/home/node/google-cloud-sdk/bin:$PATH
 RUN set -ex; \
     curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz; \

--- a/node/16-user/Dockerfile
+++ b/node/16-user/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:16-stretch
+FROM node:16-buster
 
 # Add Graphviz
 RUN set -ex; \
@@ -70,8 +70,8 @@ RUN python3 -m pip install --require-hashes -r requirements.txt
 
 # Setup Cloud SDK
 WORKDIR /home/node
-ENV CLOUD_SDK_VERSION=261.0.0 \
-    CLOUDSDK_PYTHON=/usr/bin/python \
+ENV CLOUD_SDK_VERSION=438.0.0 \
+    CLOUDSDK_PYTHON=/usr/bin/python3 \
     PATH=/home/node/google-cloud-sdk/bin:$PATH
 RUN set -ex; \
     curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz; \


### PR DESCRIPTION
Stretch is EOL, let's use Buster, and also bump the version of Google Cloud SDK to the latest one.