### PR TITLE
chore: added qt5-qmake dependency for ruby docs samples

### DIFF
--- a/ruby/multi/Dockerfile
+++ b/ruby/multi/Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update \
       postgresql \
       postgresql-contrib \
       python-openssl \
+      qt5-qmake \
       software-properties-common \
       sqlite3 \
       wget \


### PR DESCRIPTION
Adding qt5-qmake for ruby docs samples.
It will replace poltergiest (which is deprecated) with cuprite which uses qmake 