### PR TITLE
chore: update Dockerfile to install chrome and driver for Java 11

### DIFF
--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -107,4 +107,26 @@ RUN apt-get update && apt-get install -y gnupg software-properties-common curl &
 # Install jq
 RUN apt-get -y install jq
 
+# Install chrome dependencies.
+RUN echo "Y" | apt install libnss3
+RUN echo "Y" | apt install libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libgconf-2-4
+
+# Install Chrome.
+RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub -o /tmp/google.pub \
+  && cat /tmp/google.pub | apt-key add -; rm /tmp/google.pub \
+  && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list \
+  && mkdir -p /usr/share/desktop-directories \
+  && apt-get -y update && apt-get install -y google-chrome-stable
+
+# Disable the SUID sandbox so that Chrome can launch without being in a privileged container.
+RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /opt/google/chrome/google-chrome \
+  && echo "#!/bin/bash\nexec /opt/google/chrome/google-chrome.real --no-sandbox --disable-setuid-sandbox \"\$@\"" > /opt/google/chrome/google-chrome \
+  && chmod 755 /opt/google/chrome/google-chrome \
+  && ln -fs /opt/google/chrome/google-chrome /usr/bin/google-chrome
+
+# Install chrome driver.
+RUN mkdir -p /opt/selenium \
+  && curl http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip -o /opt/selenium/chromedriver_linux64.zip \
+  && cd /opt/selenium; unzip /opt/selenium/chromedriver_linux64.zip; rm -rf chromedriver_linux64.zip; ln -fs /opt/selenium/chromedriver /usr/local/bin/chromedriver;
+
 WORKDIR /workspace


### PR DESCRIPTION
Adding Chrome binary to Java 11 Dockerfile to observe the tradeoff in build time.
Main PR: https://github.com/googleapis/testing-infra-docker/pull/342