### PR TITLE
chore(proc): Add trampoline image config for Java 21

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -6,7 +6,7 @@ on Kokoro via Trampoline.
 
 ## Supported Versions
 
-Our Java client libraries currently support Java 6+.
+Our Java client libraries currently support Java 8+.
 
 ## Supported Tools
 

--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -58,7 +58,6 @@ steps:
   # GraalVM build
   - name: gcr.io/cloud-builders/docker
     args: ["build", "-t", "gcr.io/$PROJECT_ID/graalvm:${_GRAALVM_VERSION}", "--build-arg=GRAALVM_VERSION=$_GRAALVM_VERSION", "."]
-    env: 
     dir: java/graalvm
     id: graalvm-build
     waitFor: ["-"]
@@ -131,6 +130,24 @@ steps:
               "gcr.io/cloud-devrel-public-resources/java17",
       ]
     waitFor: ["java17-build"]
+    # Java 21 build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java21", "."]
+    dir: java/java21
+    id: java21-build
+    waitFor: ["-"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "gcr.io/$PROJECT_ID/java21", "--config", "java/java21.yaml", "-v"]
+    waitFor: ["java17-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+              "tag",
+              "gcr.io/$PROJECT_ID/java21",
+              "gcr.io/cloud-devrel-public-resources/java21",
+      ]
+    waitFor: ["java21-build"]
 images:
   - gcr.io/$PROJECT_ID/java8
   - gcr.io/cloud-devrel-public-resources/java8
@@ -144,3 +161,5 @@ images:
   - gcr.io/cloud-devrel-public-resources/java11014
   - gcr.io/$PROJECT_ID/java17
   - gcr.io/cloud-devrel-public-resources/java17
+  - gcr.io/$PROJECT_ID/java21
+  - gcr.io/cloud-devrel-public-resources/java21

--- a/java/java21.yaml
+++ b/java/java21.yaml
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+schemaVersion: 1.0.0
+commandTests:
+- name: "version"
+  command: ["java", "-version"]
+  # java -version outputs to stderr...
+  expectedError: ["(java|openjdk) version \"21.*\""]
+- name: "maven"
+  command: ["mvn", "-version"]
+  expectedOutput: ["Apache Maven 3.8.*"]
+- name: "gradle"
+  command: ["gradle", "-version"]
+  expectedOutput: ["Gradle 4.9"]
+- name: "gcloud"
+  command: ["gcloud", "version"]
+  expectedOutput: ["Google Cloud SDK"]
+- name: "AppEngine SDK"
+  command: ["mvn", "dependency:get", "-Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65", "-o", "-DremoteRepositories=file:~/.m2"]
+  expectedOutput: ["BUILD SUCCESS"]
+- name: "Google Play Services"
+  command: ["mvn", "dependency:get", "-Dartifact=com.google.android.google-play-services:google-play-services:1", "-o", "-DremoteRepositories=file:~/.m2"]
+  expectedOutput: ["BUILD SUCCESS"]
+- name: "xmllint tool"
+  command: ["xmllint", "--version"]
+  expectedError: ["using libxml version"]
+- name: "python"
+  command: ["python", "--version"]
+  expectedOutput: ["Python 3.9.13"]
+- name: "docker"
+  command: ["docker", "--version"]
+  expectedOutput: ["Docker version *"]

--- a/java/java21/Dockerfile
+++ b/java/java21/Dockerfile
@@ -1,0 +1,113 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM eclipse-temurin:21
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install wget && \
+    apt-get install unzip && \
+    apt -y install git && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
+    rm -rf /var/cache/apt
+
+RUN wget -q https://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip -O /tmp/maven.zip && \
+    unzip /tmp/maven.zip -d /tmp/maven && \
+    mv /tmp/maven/apache-maven-3.8.4 /usr/local/lib/maven && \
+    rm /tmp/maven.zip && \
+    ln -s $JAVA_HOME/lib $JAVA_HOME/conf
+
+RUN wget -q https://services.gradle.org/distributions/gradle-4.9-bin.zip -O /tmp/gradle.zip && \
+    mkdir -p /usr/local/lib/gradle && \
+    unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
+    rm /tmp/gradle.zip
+
+ENV PATH $PATH:/usr/local/lib/maven/bin:/usr/local/lib/gradle/gradle-4.9/bin
+
+# Install gcloud SDK
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && apt-get update -y && \
+    apt-get install google-cloud-sdk -y
+
+# Install google-play-services version 1
+RUN mkdir -p /tmp/playservices && \
+    wget -q https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -O /tmp/play-services-basement.aar && \
+    unzip -q /tmp/play-services-basement.aar -d /tmp/playservices && \
+    mvn install:install-file \
+        -Dfile=/tmp/playservices/classes.jar \
+        -DgroupId=com.google.android.google-play-services \
+        -DartifactId=google-play-services \
+        -Dversion=1 \
+        -Dpackaging=jar
+
+# Install the appengine SDK
+RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65
+
+# Adding the package path to local
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+
+# Install pyenv
+RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install python
+RUN pyenv install 3.9.13 && \
+    pyenv global 3.9.13 && \
+    python3 -m pip install --upgrade pip setuptools
+
+# Add Graphviz for Cloud Run samples
+RUN apt-get update -y && \
+    apt-get install -y graphviz && \
+    rm -rf /var/lib/apt/lists/*
+    
+# Add imagemagick for Cloud Run samples
+RUN apt-get update -y && \
+    apt-get install -y imagemagick && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install docker
+RUN apt-get update && apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        lsb-release \
+        software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        bullseye \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install Terraform
+RUN apt-get update && apt-get install -y gnupg software-properties-common curl && \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+    apt-get update && apt-get install terraform
+
+# Install jq
+RUN apt-get -y install jq
+
+WORKDIR /workspace


### PR DESCRIPTION
Add configuration files to build a new trampoline image for Java 21 runtime.
Makes a small fix to java/README file to reflect that the client libraries support at least Java 8 runtime.