### PR TITLE
fix(ruby): install libasound2 for chrome

### DIFF
--- a/ruby/multi/Dockerfile
+++ b/ruby/multi/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update \
       git \
       gpg-agent \
       imagemagick \
+      libasound2 \
       libbz2-dev \
       libffi-dev \
       libgdbm-dev \


### PR DESCRIPTION
Tests that use selenium are currently failing due to chrome refusing to start. When checking the image manually, it looks like chrome couldn't find `libasound.so.2`, so we'll see if installing that library fixes things.