### PR TITLE
fix: update php docker testing images to public buckets

### DIFF
--- a/php/cloudbuild.yaml
+++ b/php/cloudbuild.yaml
@@ -18,32 +18,44 @@ options:
 steps:
 
 # PHP 8.0
-- name: gcr.io/cloud-builders/docker
+- id: 'build-php80'
+  name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php80', '.']
   dir: 'php/php80'
   waitFor: ['-']
 
 # PHP 8.1
-- name: gcr.io/cloud-builders/docker
+- id: 'build-php81'
+  name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php81', '.']
   dir: 'php/php81'
   waitFor: ['-']
 
 # PHP 8.2
-- name: gcr.io/cloud-builders/docker
+- id: 'build-php82'
+  name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php82', '.']
   dir: 'php/php82'
   waitFor: ['-']
 
-# PHP 7.3 / 7.4 / 8.0
-# (do not build this for now, as it is not in use)
-#- name: gcr.io/cloud-builders/docker
-#  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php', '.']
-#  dir: 'php/php'
-#  waitFor: ['-']
+# Tag alternate names
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/php80',
+                'gcr.io/cloud-devrel-public-resources/php80']
+  waitFor: ['build-php80']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/php81',
+                'gcr.io/cloud-devrel-public-resources/php81']
+  waitFor: ['build-php81']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/php82',
+                'gcr.io/cloud-devrel-public-resources/php82']
+  waitFor: ['build-php82']
 
 images:
   - gcr.io/cloud-devrel-kokoro-resources/php80
+  - gcr.io/cloud-devrel-public-resources/php80
   - gcr.io/cloud-devrel-kokoro-resources/php81
+  - gcr.io/cloud-devrel-public-resources/php81
   - gcr.io/cloud-devrel-kokoro-resources/php82
-  # - gcr.io/cloud-devrel-kokoro-resources/php
+  - gcr.io/cloud-devrel-public-resources/php82


### PR DESCRIPTION
1. Update `gcr.io/cloud-devrel-kokoro-resources/php*` images to `gcr.io/cloud-devrel-public-resources/php80'`
2. This is in line with what Ruby does [here](https://github.com/googleapis/testing-infra-docker/blob/b7a0602daaf192f38b138dcc4ed22d354d3241be/ruby/cloudbuild.yaml#L46)
3. PHP has images exposed via [`cloud-devrel-public-resources`](https://pantheon.corp.google.com/gcr/images/cloud-devrel-public-resources) till php74, but not for later versions.

[b/331742181](http://b/331742181) This significantly speeds up development, because `cloud-devrel-kokoro-resources` images are not accessible to many developers within cloud sdk
