### PR TITLE
fix: add pdo_sqlsrv version to avoid php warnings

### DIFF
--- a/php/php80.yaml
+++ b/php/php80.yaml
@@ -20,6 +20,7 @@ commandTests:
 - name: "required php extentions"
   command: ["php", "-m"]
   expectedOutput: ["grpc"]
+  expectedOutput: ["pdo_sqlsrv"]
 - name: "composer"
   command: ["composer", "about"]
   expectedOutput: ["Composer - Dependency Manager for PHP - version"]

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -92,7 +92,7 @@ RUN ln -s /usr/lib/libc-client.a /usr/lib/x86_64-linux-gnu/libc-client.a && \
         --with-pear && \
         make && \
         make install && \
-        pecl install grpc pdo_sqlsrv && \
+        pecl install grpc pdo_sqlsrv-5.11.1 && \
         cp php.ini-production ${PHP_DIR}/lib/php.ini && \
         echo 'zend_extension=opcache.so' >> ${PHP_DIR}/lib/php.ini && \
         echo 'extension=grpc.so' >> ${PHP_DIR}/lib/conf.d/ext-grpc.ini && \

--- a/php/php81.yaml
+++ b/php/php81.yaml
@@ -21,6 +21,7 @@ commandTests:
   command: ["php", "-m"]
   expectedOutput: ["grpc"]
   expectedOutput: ["sodium"]
+  expectedOutput: ["pdo_sqlsrv"]
 - name: "composer"
   command: ["composer", "about"]
   expectedOutput: ["Composer - Dependency Manager for PHP - version"]

--- a/php/php82.yaml
+++ b/php/php82.yaml
@@ -20,6 +20,7 @@ commandTests:
 - name: "required php extentions"
   command: ["php", "-m"]
   expectedOutput: ["grpc"]
+  expectedOutput: ["pdo_sqlsrv"]
 - name: "composer"
   command: ["composer", "about"]
   expectedOutput: ["Composer - Dependency Manager for PHP - version"]


### PR DESCRIPTION
Adding [version number](https://pecl.php.net/package/pdo_sqlsrv/5.11.1) for a relatively sparingly php extension `pdp_sqlsrv`.

Currently, since there's is no version of `pdo_sqlsrv`, it fetches latest which is not supported on php8.0 everytime php process loads it emits a warning like below:

```
root@9e9dd96a511f:/# php -v
PHP Warning:  PHP Startup: Unable to load dynamic library 'pdo_sqlsrv.so' (tried: /opt/php80/lib/php/extensions/no-debug-non-zts-20200930/pdo_sqlsrv.so (/opt/php80/lib/php/extensions/no-debug-non-zts-20200930/pdo_sqlsrv.so: cannot open shared object file: No such file or directory), /opt/php80/lib/php/extensions/no-debug-non-zts-20200930/pdo_sqlsrv.so.so (/opt/php80/lib/php/extensions/no-debug-non-zts-20200930/pdo_sqlsrv.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
PHP 8.0.28 (cli) (built: Apr  2 2024 15:51:21) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.28, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.28, Copyright (c), by Zend Technologies
root@9e9dd96a511f:/#
```

