### PR TITLE
feat: remove php 8.0, add php 8.3

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -6,10 +6,9 @@ The images for individual versions of PHP are available at `gcr.io/cloud-devrel-
 You can try them out by running:
 
 ```sh
-$ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php74
-$ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php80
 $ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php81
 $ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php82
+$ docker run --rm -it gcr.io/cloud-devrel-kokoro-resources/php83
 ```
 
 An image containing all [supported versions][php-version-support] of PHP is available

--- a/php/cloudbuild-test.yaml
+++ b/php/cloudbuild-test.yaml
@@ -19,19 +19,6 @@ options:
  machineType: 'E2_HIGHCPU_8'
 steps:
 
-# PHP 8.0
-- id: 'build-php80'
-  name: gcr.io/cloud-builders/docker
-  args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php80', '-t', 'gcr.io/cloud-devrel-public-resources/php80', '.']
-  dir: 'php/php80'
-  waitFor: ['-']
-
-- name: gcr.io/gcp-runtimes/structure_test
-  args:
-    ['-i', 'gcr.io/cloud-devrel-kokoro-resources/php80', '--config', '/workspace/php/php80.yaml', '-v']
-  waitFor: ['build-php80']
-
 # PHP 8.1
 - id: 'build-php81'
   name: gcr.io/cloud-builders/docker
@@ -57,3 +44,17 @@ steps:
   args:
     ['-i', 'gcr.io/cloud-devrel-kokoro-resources/php82', '--config', '/workspace/php/php82.yaml', '-v']
   waitFor: ['build-php82']
+
+# PHP 8.0
+- id: 'build-php83'
+  name: gcr.io/cloud-builders/docker
+  args:
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php83', '-t', 'gcr.io/cloud-devrel-public-resources/php83', '.']
+  dir: 'php/php83'
+  waitFor: ['-']
+
+- name: gcr.io/gcp-runtimes/structure_test
+  args:
+    ['-i', 'gcr.io/cloud-devrel-kokoro-resources/php83', '--config', '/workspace/php/php83.yaml', '-v']
+  waitFor: ['build-php83']
+

--- a/php/cloudbuild.yaml
+++ b/php/cloudbuild.yaml
@@ -19,19 +19,6 @@ options:
  machineType: 'E2_HIGHCPU_8'
 steps:
 
-# PHP 8.0
-- id: 'build-php80'
-  name: gcr.io/cloud-builders/docker
-  args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php80', '-t', 'gcr.io/cloud-devrel-public-resources/php80', '.']
-  dir: 'php/php80'
-  waitFor: ['-']
-
-- name: gcr.io/gcp-runtimes/structure_test
-  args:
-    ['-i', 'gcr.io/cloud-devrel-kokoro-resources/php80', '--config', '/workspace/php/php80.yaml', '-v']
-  waitFor: ['build-php80']
-
 # PHP 8.1
 - id: 'build-php81'
   name: gcr.io/cloud-builders/docker
@@ -58,10 +45,23 @@ steps:
     ['-i', 'gcr.io/cloud-devrel-kokoro-resources/php82', '--config', '/workspace/php/php82.yaml', '-v']
   waitFor: ['build-php82']
 
+# PHP 8.0
+- id: 'build-php83'
+  name: gcr.io/cloud-builders/docker
+  args:
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php83', '-t', 'gcr.io/cloud-devrel-public-resources/php83', '.']
+  dir: 'php/php83'
+  waitFor: ['-']
+
+- name: gcr.io/gcp-runtimes/structure_test
+  args:
+    ['-i', 'gcr.io/cloud-devrel-kokoro-resources/php83', '--config', '/workspace/php/php83.yaml', '-v']
+  waitFor: ['build-php83']
+
 images:
-  - gcr.io/cloud-devrel-kokoro-resources/php80
-  - gcr.io/cloud-devrel-public-resources/php80
   - gcr.io/cloud-devrel-kokoro-resources/php81
   - gcr.io/cloud-devrel-public-resources/php81
   - gcr.io/cloud-devrel-kokoro-resources/php82
   - gcr.io/cloud-devrel-public-resources/php82
+  - gcr.io/cloud-devrel-kokoro-resources/php83
+  - gcr.io/cloud-devrel-public-resources/php83

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
 ENV PHP_DIR=/opt/php82
-ENV PHP_SRC_DIR=/usr/local/src/php80-build
+ENV PHP_SRC_DIR=/usr/local/src/php82-build
 ENV PATH=${PATH}:/usr/local/bin:${PHP_DIR}/bin
 ENV PHP_VERISON=8.2.6
 

--- a/php/php83.yaml
+++ b/php/php83.yaml
@@ -16,7 +16,7 @@ schemaVersion: 1.0.0
 commandTests:
 - name: "version"
   command: ["php", "-version"]
-  expectedOutput: ["PHP 8.0"]
+  expectedOutput: ["PHP 8.3"]
 - name: "required php extentions"
   command: ["php", "-m"]
   expectedOutput: ["grpc"]

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -1,8 +1,8 @@
 FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
-ENV PHP_DIR=/opt/php80
-ENV PHP_SRC_DIR=/usr/local/src/php80-build
+ENV PHP_DIR=/opt/php83
+ENV PHP_SRC_DIR=/usr/local/src/php83-build
 ENV PATH=${PATH}:/usr/local/bin:${PHP_DIR}/bin
-ENV PHP_VERISON=8.0.28
+ENV PHP_VERISON=8.3.7
 
 RUN apt-get update && \
     apt-get -y install \


### PR DESCRIPTION
PHP 8.0 is EOL, and PHP 8.3 was released over 6 months ago. We should remove the PHP 8 container and begin testing on PHP 8.3

See https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1963