### PR TITLE
fix: use Python 3.7 specific version of get-pip.py

### DIFF
--- a/python/cloud-devrel-kokoro-resources/python-base/Dockerfile
+++ b/python/cloud-devrel-kokoro-resources/python-base/Dockerfile
@@ -121,7 +121,8 @@ RUN for PYTHON_VERSION in 3.7.17 3.8.18 3.9.18 3.10.13 3.11.6 3.12.0; do \
 # If the environment variable is called "PIP_VERSION", pip explodes with
 # "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 23.1.2
-RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
+RUN wget --no-check-certificate -O /tmp/get-pip-3-7.py 'https://bootstrap.pypa.io/pip/3.7/get-pip.py' \
+    && wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
     && python3.11 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
 
   # we use "--force-reinstall" for the case where the version of pip we're trying to install is the
@@ -135,12 +136,13 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
 # Ensure Pip for all python3 versions
-RUN python3.7 /tmp/get-pip.py
+RUN python3.7 /tmp/get-pip-3-7.py
 RUN python3.8 /tmp/get-pip.py
 RUN python3.9 /tmp/get-pip.py
 RUN python3.10 /tmp/get-pip.py
 RUN python3.12 /tmp/get-pip.py
 
+RUN rm /tmp/get-pip-3-7.py
 RUN rm /tmp/get-pip.py
 
 # Test Pip

--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -159,7 +159,8 @@ RUN echo "conda activate" >> "${HOME}/.bashrc"
 # If the environment variable is called "PIP_VERSION", pip explodes with
 # "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 21.3.1
-RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
+RUN wget --no-check-certificate -O /tmp/get-pip-3-7.py 'https://bootstrap.pypa.io/pip/3.7/get-pip.py' \
+    && wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
     && python3.10 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
 
   # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
@@ -172,7 +173,7 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
 # Ensure Pip for all python3 versions
-RUN python3.7 /tmp/get-pip.py
+RUN python3.7 /tmp/get-pip-3-7.py
 RUN python3.8 /tmp/get-pip.py
 RUN python3.9 /tmp/get-pip.py
 RUN python3.11 /tmp/get-pip.py

--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -179,6 +179,7 @@ RUN python3.9 /tmp/get-pip.py
 RUN python3.11 /tmp/get-pip.py
 RUN python3.12 /tmp/get-pip.py
 
+RUN rm /tmp/get-pip-3-7.py
 RUN rm /tmp/get-pip.py
 
 # Test Pip


### PR DESCRIPTION
Follow-up to build failure in https://github.com/googleapis/testing-infra-docker/pull/394

```
Step #1 - "python-base":  ---> 5975b0e35639
Step #1 - "python-base": Step 15/30 : RUN python3.7 /tmp/get-pip.py
Step #1 - "python-base":  ---> Running in d8857ce9fb52
Step #1 - "python-base": ERROR: This script does not work on Python 3.7. The minimum supported Python version is 3.8. Please use https://bootstrap.pypa.io/pip/3.7/get-pip.py instead.
Step #1 - "python-base": The command '/bin/sh -c python3.7 /tmp/get-pip.py' returned a non-zero code: 1
Finished Step #1 - "python-base"
ERROR
ERROR: build step 1 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
```