### PR TITLE
feat(go): add Go 1.23 support

### DIFF
--- a/go/cloudbuild-test.yaml
+++ b/go/cloudbuild-test.yaml
@@ -17,36 +17,36 @@
 
 timeout: 7200s
 steps:
-  # Go 1.20 build
+  # Go 1.21 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/go119", "."]
-    dir: go/go120
-    id: go120-build
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/go121", "."]
+    dir: go/go121
+    id: go121-build
     waitFor: ["-"]
   - name: gcr.io/gcp-runtimes/structure_test
     args:
       [
         "-i",
-        "gcr.io/$PROJECT_ID/go120",
+        "gcr.io/$PROJECT_ID/go121",
         "--config",
-        "/workspace/go/go120.yaml",
+        "/workspace/go/go121.yaml",
         "-v",
       ]
-    waitFor: ["go120-build"]
+    waitFor: ["go121-build"]
 
-  # Go 1.22 build
+  # Go 1.23 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/go122", "."]
-    dir: go/go122
-    id: go122-build
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/go123", "."]
+    dir: go/go123
+    id: go123-build
     waitFor: ["-"]
   - name: gcr.io/gcp-runtimes/structure_test
     args:
       [
         "-i",
-        "gcr.io/$PROJECT_ID/go122",
+        "gcr.io/$PROJECT_ID/go123",
         "--config",
-        "/workspace/go/go122.yaml",
+        "/workspace/go/go123.yaml",
         "-v",
       ]
-    waitFor: ["go122-build"]
+    waitFor: ["go123-build"]

--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -17,40 +17,40 @@
 
 timeout: 7200s # 2 hours
 steps:
-  # Go 1.20 build
+  # Go 1.21 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/go120", "."]
-    dir: go/go120
-    id: go120-build
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/go121", "."]
+    dir: go/go121
+    id: go121-build
     waitFor: ["-"]
   - name: gcr.io/gcp-runtimes/structure_test
     args:
       [
         "-i",
-        "gcr.io/$PROJECT_ID/go120",
+        "gcr.io/$PROJECT_ID/go121",
         "--config",
-        "/workspace/go/go120.yaml",
+        "/workspace/go/go121.yaml",
         "-v",
       ]
-    waitFor: ["go120-build"]
+    waitFor: ["go121-build"]
 
-    # Go 1.22 build
+    # Go 1.23 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/go122", "."]
-    dir: go/go122
-    id: go122-build
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/go123", "."]
+    dir: go/go123
+    id: go123-build
     waitFor: ["-"]
   - name: gcr.io/gcp-runtimes/structure_test
     args:
       [
         "-i",
-        "gcr.io/$PROJECT_ID/go122",
+        "gcr.io/$PROJECT_ID/go123",
         "--config",
-        "/workspace/go/go122.yaml",
+        "/workspace/go/go123.yaml",
         "-v",
       ]
-    waitFor: ["go122-build"]
+    waitFor: ["go123-build"]
 
 images:
-  - gcr.io/$PROJECT_ID/go120
-  - gcr.io/$PROJECT_ID/go122
+  - gcr.io/$PROJECT_ID/go121
+  - gcr.io/$PROJECT_ID/go123

--- a/go/go121/Dockerfile
+++ b/go/go121/Dockerfile
@@ -44,7 +44,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN go install honnef.co/go/tools/cmd/staticcheck@latest && \
+RUN GOTOOLCHAIN='auto' go install honnef.co/go/tools/cmd/staticcheck@latest && \
     go install github.com/jstemmer/go-junit-report@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest

--- a/go/go122/Dockerfile
+++ b/go/go122/Dockerfile
@@ -44,7 +44,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN go install honnef.co/go/tools/cmd/staticcheck@latest && \
+RUN GOTOOLCHAIN='auto' go install honnef.co/go/tools/cmd/staticcheck@latest && \
     go install github.com/jstemmer/go-junit-report@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest

--- a/go/go123.yaml
+++ b/go/go123.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ schemaVersion: 1.0.0
 commandTests:
   - name: "version"
     command: ["go", "version"]
-    expectedOutput: ["go version go1.20"]
+    expectedOutput: ["go version go1.23"]
   - name: "gcloud"
     command: ["gcloud", "version"]
     expectedOutput: ["Google Cloud SDK"]

--- a/go/go123/Dockerfile
+++ b/go/go123/Dockerfile
@@ -44,7 +44,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN go install honnef.co/go/tools/cmd/staticcheck@latest && \
+RUN GOTOOLCHAIN='auto' go install honnef.co/go/tools/cmd/staticcheck@latest && \
     go install github.com/jstemmer/go-junit-report@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest

--- a/go/go123/Dockerfile
+++ b/go/go123/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20
+FROM golang:1.23
 
 # Install dependencies
 RUN set -ex; \


### PR DESCRIPTION
Note: we need to set toolchain to auto just for installing tools. We want to keep the image default of local for CI and fail if a dependency tries to update the go version.

Ref: https://github.com/docker-library/golang/issues/472