### PR TITLE
chore: Update cloud build triggers to use cloud logging only as a log entry

### DIFF
--- a/elixir/cloudbuild.yaml
+++ b/elixir/cloudbuild.yaml
@@ -204,3 +204,6 @@ images:
 - gcr.io/$PROJECT_ID/elixir114
 - gcr.io/$PROJECT_ID/elixir115
 - gcr.io/$PROJECT_ID/elixir116
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -51,9 +51,9 @@ steps:
       ]
     waitFor: ["go123-build"]
 
-options:
-  logging: CLOUD_LOGGING_ONLY
-
 images:
   - gcr.io/$PROJECT_ID/go121
   - gcr.io/$PROJECT_ID/go123
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -51,6 +51,9 @@ steps:
       ]
     waitFor: ["go123-build"]
 
+options:
+  logging: CLOUD_LOGGING_ONLY
+
 images:
   - gcr.io/$PROJECT_ID/go121
   - gcr.io/$PROJECT_ID/go123

--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -219,3 +219,6 @@ images:
   - gcr.io/cloud-devrel-public-resources/java17
   - gcr.io/$PROJECT_ID/java21
   - gcr.io/cloud-devrel-public-resources/java21
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/node/cloudbuild.yaml
+++ b/node/cloudbuild.yaml
@@ -24,3 +24,6 @@ steps:
 images:
   - gcr.io/cloud-devrel-kokoro-resources/node
   - gcr.io/cloud-devrel-public-resources/node
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/php/cloudbuild.yaml
+++ b/php/cloudbuild.yaml
@@ -17,6 +17,7 @@
 timeout: 21600s  # 6 hours
 options:
  machineType: 'E2_HIGHCPU_8'
+ logging: CLOUD_LOGGING_ONLY
 steps:
 
 # PHP 8.1

--- a/python/cloudbuild.yaml
+++ b/python/cloudbuild.yaml
@@ -57,6 +57,7 @@ steps:
 
 options:
   machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
 
 images:
   - gcr.io/cloud-devrel-kokoro-resources/google-cloud-python/autosynth

--- a/ruby/cloudbuild.yaml
+++ b/ruby/cloudbuild.yaml
@@ -57,3 +57,6 @@ images:
   - gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi
   - gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-release
   - gcr.io/cloud-devrel-public-resources/yoshi-ruby/multi
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This is necessary as part of the switch to use non default service account.