### PR TITLE
fix(go): apply GOTOOLCHAIN to all subcommands

### DIFF
--- a/go/go121/Dockerfile
+++ b/go/go121/Dockerfile
@@ -44,9 +44,10 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN GOTOOLCHAIN='auto' go install honnef.co/go/tools/cmd/staticcheck@latest && \
+RUN (export GOTOOLCHAIN='auto' && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest && \
     go install github.com/jstemmer/go-junit-report@latest && \
     go install golang.org/x/lint/golint@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest
+    go install golang.org/x/tools/cmd/goimports@latest)
 
 WORKDIR $GOPATH

--- a/go/go122/Dockerfile
+++ b/go/go122/Dockerfile
@@ -44,9 +44,10 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN GOTOOLCHAIN='auto' go install honnef.co/go/tools/cmd/staticcheck@latest && \
+RUN (export GOTOOLCHAIN='auto' && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest && \
     go install github.com/jstemmer/go-junit-report@latest && \
     go install golang.org/x/lint/golint@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest
+    go install golang.org/x/tools/cmd/goimports@latest)
 
 WORKDIR $GOPATH

--- a/go/go123/Dockerfile
+++ b/go/go123/Dockerfile
@@ -44,9 +44,10 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get install google-cloud-sdk -y
 
 # Install tools used in build
-RUN GOTOOLCHAIN='auto' go install honnef.co/go/tools/cmd/staticcheck@latest && \
+RUN (export GOTOOLCHAIN='auto' && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest && \
     go install github.com/jstemmer/go-junit-report@latest && \
     go install golang.org/x/lint/golint@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest
+    go install golang.org/x/tools/cmd/goimports@latest)
 
 WORKDIR $GOPATH


### PR DESCRIPTION
Create a sub-shell and export the envvar to apply to all commands.

Noticed in #398