### PR TITLE
fix(node): update python version for node14 and release image name

### DIFF
--- a/node/14-user/Dockerfile
+++ b/node/14-user/Dockerfile
@@ -60,8 +60,8 @@ RUN echo 'export PATH="/home/node/.pyenv/bin:$PATH"' >> ~/.profile && \
 ENV PATH="/home/node/.pyenv/bin:/home/node/.pyenv/shims:${PATH}"
 
 # Install python
-RUN pyenv install 3.7.4 && \
-    pyenv global 3.7.4 && \
+RUN pyenv install 3.10.13 && \
+    pyenv global 3.10.13 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Install gcp-uploader and gcp-releasetool and their dependencies.

--- a/node/cloudbuild-release.yaml
+++ b/node/cloudbuild-release.yaml
@@ -17,12 +17,12 @@ steps:
 
 # Node 14
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node:14-user', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node14', '.']
   dir: 'node/14-user'
   waitFor: ['-']
 
 images:
-  - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node
+  - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node14
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/ruby/cloudbuild-release.yaml
+++ b/ruby/cloudbuild-release.yaml
@@ -19,7 +19,7 @@ steps:
 - id: 'build-release'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/yoshi-ruby/release', '.']
-  dir: 'ruby/release'
+  dir: 'ruby/multi'
   waitFor: ['-']
 
 # Results

--- a/ruby/cloudbuild-release.yaml
+++ b/ruby/cloudbuild-release.yaml
@@ -19,7 +19,7 @@ steps:
 - id: 'build-release'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/yoshi-ruby/release', '.']
-  dir: 'ruby/multi'
+  dir: 'ruby/release'
   waitFor: ['-']
 
 # Results


### PR DESCRIPTION
- Updated python version to match Node 18 (existing version for node 14 was no longer supported by gcloud)
- Renamed node release image to release image convention language + version