### PR TITLE
build(elixir-release): allow failure on fetching cached plt files

### DIFF
--- a/elixir/cloudbuild-release.yaml
+++ b/elixir/cloudbuild-release.yaml
@@ -19,6 +19,7 @@ steps:
 - name: gcr.io/cloud-builders/gsutil
   args: ['cp', '-r', 'gs://release-image-cache/elixir-artifacts/elixir*', '/workspace/elixir/plt_builder/plts/']
   id: load-plts
+  allowFailure: true
   waitFor: ['-']
 
 # Elixir 1.14 build


### PR DESCRIPTION
When first creating the images, there are no cached files in GCS so this command fails.