### PR TITLE
fix(java): Add java 11 to release builds list

### DIFF
--- a/java/cloudbuild-release.yaml
+++ b/java/cloudbuild-release.yaml
@@ -25,6 +25,17 @@ steps:
       ["-i", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8", "--config", "java/java8.yaml", "-v"]
     waitFor: ["java8-build"]
 
+  # Java 11 build for publish docs
+  - name: gcr.io/cloud-builders/docker
+    args: [ "build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java11", "." ]
+    dir: java/java11
+    id: java11-build
+    waitFor: [ "-" ]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      [ "-i", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java11", "--config", "java/java11.yaml", "-v" ]
+    waitFor: [ "java11-build" ]
+
   # Java 17 build specifically for java-storage
   - name: gcr.io/cloud-builders/docker
     args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java17", "."]
@@ -38,6 +49,7 @@ steps:
 
 images:
   - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8
+  - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java11
   - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java17
 
 options:

--- a/node/14-user/Dockerfile
+++ b/node/14-user/Dockerfile
@@ -60,8 +60,8 @@ RUN echo 'export PATH="/home/node/.pyenv/bin:$PATH"' >> ~/.profile && \
 ENV PATH="/home/node/.pyenv/bin:/home/node/.pyenv/shims:${PATH}"
 
 # Install python
-RUN pyenv install 3.7.4 && \
-    pyenv global 3.7.4 && \
+RUN pyenv install 3.10.13 && \
+    pyenv global 3.10.13 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Install gcp-uploader and gcp-releasetool and their dependencies.

--- a/ruby/cloudbuild-release.yaml
+++ b/ruby/cloudbuild-release.yaml
@@ -19,7 +19,7 @@ steps:
 - id: 'build-release'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/yoshi-ruby/release', '.']
-  dir: 'ruby/release'
+  dir: 'ruby/multi'
   waitFor: ['-']
 
 # Results

--- a/ruby/cloudbuild-release.yaml
+++ b/ruby/cloudbuild-release.yaml
@@ -19,7 +19,7 @@ steps:
 - id: 'build-release'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/yoshi-ruby/release', '.']
-  dir: 'ruby/multi'
+  dir: 'ruby/release'
   waitFor: ['-']
 
 # Results


### PR DESCRIPTION
Java 11 is used by publish docs for projects such as java-logging-logback