### PR TITLE
chore(node): Setup `npm` on Node 18

### DIFF
--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -14,6 +14,11 @@
 
 FROM node:18-buster
 
+# Setup npm
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+RUN npm i -g npm@10
+RUN npm config set update-notifier false
+
 # Add Graphviz
 RUN set -ex; \
   apt-get update -y; \

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -17,7 +17,7 @@ FROM node:18-buster
 # Setup npm
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 RUN npm i -g npm@10
-RUN npm config set update-notifier false
+RUN npm config -g set update-notifier false
 
 # Add Graphviz
 RUN set -ex; \


### PR DESCRIPTION
The installed version of `npm` has a few bugs. This will ensure the build is on a newer version of `npm` along with disabling the npm update check.