### PR TITLE
ci: run `npm` config as `User: node`

### DIFF
--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 
 USER node
 
-# Setup npm's config and allow anyone to write to it
+# Setup npm's config
 ENV NPM_CONFIG_PREFIX=/home/node/.npm
 RUN npm config -g set update-notifier false
 

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -14,15 +14,10 @@
 
 FROM node:18-buster
 
-# Setup npm's config and allow anyone to write to it
-ENV NPM_CONFIG_PREFIX=/home/node/.npm
-RUN mkdir -p $NPM_CONFIG_PREFIX && chmod 777 $NPM_CONFIG_PREFIX
-RUN npm config -g set update-notifier false
-
 # Add Graphviz
 RUN set -ex; \
-  apt-get update -y; \
-  apt-get install -y \
+    apt-get update -y; \
+    apt-get install -y \
     graphviz \
     apt-transport-https \
     ca-certificates \
@@ -31,14 +26,14 @@ RUN set -ex; \
     lsb-release \
     software-properties-common \
     ; \
-  rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 # Install docker
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/debian \
-        $(lsb_release -cs) \
-        stable" && \
+    "deb [arch=amd64] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) \
+    stable" && \
     apt-get update && \
     apt-get install -y docker-ce docker-ce-cli containerd.io
 
@@ -54,6 +49,10 @@ RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python-openssl
 
 USER node
+
+# Setup npm's config and allow anyone to write to it
+ENV NPM_CONFIG_PREFIX=/home/node/.npm
+RUN npm config -g set update-notifier false
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -14,8 +14,9 @@
 
 FROM node:18-buster
 
-# Setup npm's config
-ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+# Setup npm's config and allow anyone to write to it
+ENV NPM_CONFIG_PREFIX=/home/node/.npm
+RUN mkdir -p $NPM_CONFIG_PREFIX && chmod 777 $NPM_CONFIG_PREFIX
 RUN npm config -g set update-notifier false
 
 # Add Graphviz

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 USER node
 
 # Setup npm's config
-ENV NPM_CONFIG_PREFIX=/home/node/.npm
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 RUN npm config -g set update-notifier false
 
 # Install pyenv

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -50,8 +50,9 @@ RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 
 USER node
 
-# Setup npm's config
+# Setup npm and ensure anyone can read/write to the global, shared config
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+RUN mkdir -p $NPM_CONFIG_PREFIX && chmod 777 $NPM_CONFIG_PREFIX
 RUN npm config -g set update-notifier false
 RUN npm i -g npm@`npm --version`
 

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -16,8 +16,8 @@ FROM node:18-buster
 
 # Add Graphviz
 RUN set -ex; \
-    apt-get update -y; \
-    apt-get install -y \
+  apt-get update -y; \
+  apt-get install -y \
     graphviz \
     apt-transport-https \
     ca-certificates \
@@ -26,14 +26,14 @@ RUN set -ex; \
     lsb-release \
     software-properties-common \
     ; \
-    rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*
 
 # Install docker
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/debian \
-    $(lsb_release -cs) \
-    stable" && \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
     apt-get update && \
     apt-get install -y docker-ce docker-ce-cli containerd.io
 

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -53,6 +53,7 @@ USER node
 # Setup npm's config
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 RUN npm config -g set update-notifier false
+RUN npm i -g npm@`npm --version`
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \


### PR DESCRIPTION
Looking at this build, we can see `.npm-global` is being created as `root` rather than user `node`:
- commit: https://github.com/googleapis/gaxios/pull/669/commits/f37b01bf6e4e00979d35e0850f0b234e0a13ced7
- log: https://btx.cloud.google.com/invocations/d53cfd6a-e9f7-4ec7-a800-63f9094cb782/targets/cloud-devrel%2Fclient-libraries%2Fnodejs%2Fpresubmit%2Fgoogleapis%2Fgaxios%2Fnode18%2Fsamples-test/log

This is causing access errors downstream, as `kbuilder` cannot access this directory and fails.