### PR TITLE
chore(codeowners): Update the ruby codeowner to the teamsync-managed team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,5 @@
 /java       @googleapis/yoshi-java @googleapis/cloud-java-team-teamsync
 /node       @googleapis/yoshi-nodejs
 /python     @googleapis/yoshi-python
-/ruby       @googleapis/yoshi-ruby
+/ruby       @googleapis/ruby-team
 /php        @googleapis/yoshi-php


### PR DESCRIPTION
(Similar to #419)