### PR TITLE
deps: java17 to use Maven 3.9.9 from Airlock

### DIFF
--- a/java/java17.yaml
+++ b/java/java17.yaml
@@ -20,7 +20,7 @@ commandTests:
   expectedError: ["(java|openjdk) version \"17.*\""]
 - name: "maven"
   command: ["mvn", "-version"]
-  expectedOutput: ["Apache Maven 3.8.*"]
+  expectedOutput: ["Apache Maven 3.9.*"]
 - name: "gradle"
   command: ["gradle", "-version"]
   expectedOutput: ["Gradle 4.9"]

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -14,7 +14,7 @@
 
 # eclipse-temurin:17 as of Jan 9th, 2025
 # https://hub.docker.com/layers/library/eclipse-temurin/17/images/sha256-227c7dac267fde2625cee1dd978006a09c3f2048544b72597160620675da2668
-FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:7fccb2a944c8caed3a1f7e56a02ca52cebe5a95e06cb3e4fd35e26b9a6e7dfeb
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin@sha256:7fccb2a944c8caed3a1f7e56a02ca52cebe5a95e06cb3e4fd35e26b9a6e7dfeb
 
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# https://hub.docker.com/layers/library/eclipse-temurin/17/images/sha256-cdb63d76e280973f6afbe4658db03757c7fc4bad3168cd583435752112e74b9a
-FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin@sha256:227c7dac267fde2625cee1dd978006a09c3f2048544b72597160620675da2668
+# eclipse-temurin:17 as of Jan 9th, 2025
+# https://hub.docker.com/layers/library/eclipse-temurin/17/images/sha256-227c7dac267fde2625cee1dd978006a09c3f2048544b72597160620675da2668
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:7fccb2a944c8caed3a1f7e56a02ca52cebe5a95e06cb3e4fd35e26b9a6e7dfeb
 
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # https://hub.docker.com/layers/library/eclipse-temurin/17/images/sha256-cdb63d76e280973f6afbe4658db03757c7fc4bad3168cd583435752112e74b9a
-FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin@sha256:7fccb2a944c8caed3a1f7e56a02ca52cebe5a95e06cb3e4fd35e26b9a6e7dfeb
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin@sha256:227c7dac267fde2625cee1dd978006a09c3f2048544b72597160620675da2668
 
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:17
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:d3f04985c6a68415e36c0a6468d0f8316f27d4dbee77bc459257ba444224bd9f
 
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin:17
+# https://hub.docker.com/layers/library/eclipse-temurin/17/images/sha256-cdb63d76e280973f6afbe4658db03757c7fc4bad3168cd583435752112e74b9a
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin@sha256:7fccb2a944c8caed3a1f7e56a02ca52cebe5a95e06cb3e4fd35e26b9a6e7dfeb
 
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin:latest
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin:17
 
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -24,18 +24,17 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
     rm -rf /var/cache/apt
 
-RUN wget -q https://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip -O /tmp/maven.zip && \
-    unzip /tmp/maven.zip -d /tmp/maven && \
-    mv /tmp/maven/apache-maven-3.8.4 /usr/local/lib/maven && \
-    rm /tmp/maven.zip && \
-    ln -s $JAVA_HOME/lib $JAVA_HOME/conf
+ENV MAVEN_HOME=/usr/share/maven
+
+# 3.9.9-eclipse-temurin-11-alpine
+COPY --from=us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:d3f04985c6a68415e36c0a6468d0f8316f27d4dbee77bc459257ba444224bd9f ${MAVEN_HOME} ${MAVEN_HOME}
 
 RUN wget -q https://services.gradle.org/distributions/gradle-4.9-bin.zip -O /tmp/gradle.zip && \
     mkdir -p /usr/local/lib/gradle && \
     unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
     rm /tmp/gradle.zip
 
-ENV PATH $PATH:/usr/local/lib/maven/bin:/usr/local/lib/gradle/gradle-4.9/bin
+ENV PATH $PATH:${MAVEN_HOME}/bin:/usr/local/lib/gradle/gradle-4.9/bin
 
 # Install gcloud SDK
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
@@ -46,7 +45,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN mkdir -p /tmp/playservices && \
     wget -q https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -O /tmp/play-services-basement.aar && \
     unzip -q /tmp/play-services-basement.aar -d /tmp/playservices && \
-    mvn install:install-file \
+    mvn -V install:install-file \
         -Dfile=/tmp/playservices/classes.jar \
         -DgroupId=com.google.android.google-play-services \
         -DartifactId=google-play-services \
@@ -54,7 +53,7 @@ RUN mkdir -p /tmp/playservices && \
         -Dpackaging=jar
 
 # Install the appengine SDK
-RUN mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65
+RUN mvn -V dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65
 
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:d3f04985c6a68415e36c0a6468d0f8316f27d4dbee77bc459257ba444224bd9f
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/eclipse-temurin:latest
 
 RUN apt-get update && \
     apt-get -y upgrade && \


### PR DESCRIPTION
Java 17 container image to use Maven 3.9.9 from Airlock repository. The new Maven version addresses missing dependency problems (b/383221175#comment18).