### PR TITLE
build(python-multi): update default python runtime to 3.10

### DIFF
--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -185,8 +185,8 @@ RUN python3.11 -m pip
 RUN python3.12 -m pip
 RUN python3.13 -m pip
 
-# Use python 3.9 by default
-RUN python3.9 -m venv /venv
+# Use python 3.10 by default
+RUN python3.10 -m venv /venv
 ENV PATH /venv/bin:$PATH
 
 COPY requirements.txt /requirements.txt


### PR DESCRIPTION
Python 3.9 [will be end of life soon](https://devguide.python.org/versions/#python-release-cycle). This PR changes the default python version in the `*python-multi` images such as `gcr.io/cloud-devrel-kokoro-resources/python-multi:latest` from 3.9 to 3.10

Towards b/391428710

See local testing below

Current
```
partheniou@partheniou-vm-3:~$ docker run --rm -it --entrypoint /bin/bash gcr.io/cloud-devrel-kokoro-resources/python-multi:latest 
root@15cf9e4f3e50:/# python3
Python 3.9.20 (main, Nov  6 2024, 21:23:12) 
```

Next
```
partheniou@partheniou-vm-3:~$ docker run --rm -it --entrypoint /bin/bash gcr.io/cloud-devrel-kokoro-resources/python-multi:latest 
root@748bdbf485dd:/# python3
Python 3.10.15 (main, Nov  5 2024, 22:03:16) [GCC 13.2.0] on linux
```