### PR TITLE
feat: add syft release image

### DIFF
--- a/syft/Dockerfile
+++ b/syft/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM marketplace.gcr.io/google/ubuntu2404
+
+ENV SYFT_VERSION=1.19.0
+
+# update SSL certs
+RUN apt-get update -y && \
+    apt-get install -y ca-certificates
+
+RUN mkdir /workspace
+
+WORKDIR /workspace
+
+ADD https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.deb /workspace/syft.deb
+RUN dpkg -i syft.deb
+
+ENTRYPOINT ["syft"]

--- a/syft/cloudbuild-release.yaml
+++ b/syft/cloudbuild-release.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 7200s  # 2 hours
+steps:
+
+# Build Ruby multi-use image
+- id: 'build'
+  name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft', '.']
+  dir: 'syft'
+  waitFor: ['-']
+
+# Results
+images:
+  - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/syft/cloudbuild-test.yaml
+++ b/syft/cloudbuild-test.yaml
@@ -1,0 +1,35 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 7200s  # 2 hours
+steps:
+
+# Build Ruby multi-use image
+- id: 'build'
+  name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft', '.']
+  dir: 'syft'
+  waitFor: ['-']
+- name: gcr.io/gcp-runtimes/structure_test
+  args:
+    [
+      "-i",
+      "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft",
+      "--config",
+      "/workspace/syft/syft.yaml",
+      "-v",
+    ]
+  waitFor: ["build"]
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/syft/syft.yaml
+++ b/syft/syft.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+schemaVersion: 1.0.0
+commandTests:
+  - name: "version"
+    command: ["syft", "--version"]
+    expectedOutput: ["syft 1.19.0"]


### PR DESCRIPTION
We may need to run `syft` during releases so we maintain our own docker image with a specific `syft` version installed.