### PR TITLE
feat: create ruby release image

### DIFF
--- a/ruby/cloudbuild-release.yaml
+++ b/ruby/cloudbuild-release.yaml
@@ -16,15 +16,21 @@ timeout: 7200s  # 2 hours
 steps:
 
 # Build Ruby multi-use image
-- id: 'build-release'
+- id: 'build-multi'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-multi', '.']
   dir: 'ruby/multi'
+  waitFor: ['-']
+- id: 'build-release'
+  name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-release', '.']
+  dir: 'ruby/release'
   waitFor: ['-']
 
 # Results
 images:
   - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-multi
+  - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-release
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/ruby/cloudbuild-test.yaml
+++ b/ruby/cloudbuild-test.yaml
@@ -18,32 +18,43 @@ steps:
 # Build Ruby multi-use image
 - id: 'build-multi'
   name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi', '.']
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi'
+    - '-t'
+    - 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node'
+    - '-t'
+    - 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/autosynth'
+    - '-t'
+    - 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release'
+    - '-t'
+    - 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi'
+    - '-t'
+    - 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-release'
+    - '-t'
+    - 'gcr.io/cloud-devrel-public-resources/yoshi-ruby/multi'
+    - '.'
   dir: 'ruby/multi'
   waitFor: ['-']
 
-# Tag alternate names
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi',
-                'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node']
-  waitFor: ['build-multi']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi',
-                'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/autosynth']
-  waitFor: ['build-multi']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi',
-                'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release']
-  waitFor: ['build-multi']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi',
-                'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi']
-  waitFor: ['build-multi']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi',
-                'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-release']
-  waitFor: ['build-multi']
-- name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi',
-                'gcr.io/cloud-devrel-public-resources/yoshi-ruby/multi']
-  waitFor: ['build-multi']
+- id: 'build-release'
+  name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/release'
+    - '.'
+  dir: 'ruby/release'
+  waitFor: ['-']
+- id: 'test-release'
+  name: gcr.io/gcp-runtimes/structure_test
+  args:
+    [
+      '-i',
+      'gcr.io/$PROJECT_ID/release',
+      '--config',
+      '/workspace/ruby/release.yaml',
+      '-v',
+    ]
+  waitFor: ['build-release']

--- a/ruby/release.yaml
+++ b/ruby/release.yaml
@@ -1,0 +1,31 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+schemaVersion: 1.0.0
+commandTests:
+  - name: "ruby version"
+    command: ["ruby", "-v"]
+    expectedOutput: ["ruby 3.3.7"]
+  - name: "syft version"
+    command: ["syft", "--version"]
+    expectedOutput: ["syft 1.19.0"]
+  - name: "python version"
+    command: ["python3", "--version"]
+    expectedOutput: ["Python 3.10.16"]
+  - name: "gcloud version"
+    command: ["gcloud", "version"]
+    expectedOutput: ["Google Cloud SDK"]
+  - name: "gh version"
+    command: ["gh", "--version"]
+    expectedOutput: ["gh version 2.65.0"]

--- a/ruby/release/Dockerfile
+++ b/ruby/release/Dockerfile
@@ -1,0 +1,173 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:focal
+
+ENTRYPOINT /bin/bash
+
+# Version notes:
+# * The gems gem is pinned to 1.2.0 because 1.3.0 requires Ruby 3.1. We can
+#   update it to 1.3.0 once we drop Ruby 3.0 support.
+# * The bundler gem is pinned to 2.5.23 because 2.6 requires Ruby 3.1. We can
+#   update it to 2.6 once we drop Ruby 3.0 support.
+ENV RUBY_33_VERSION=3.3.7 \
+    BUNDLER_VERSION=2.5.23 \
+    RAKE_VERSION=13.2.1 \
+    TOYS_VERSION=0.15.6 \
+    GEMS_VERSION=1.2.0 \
+    JWT_VERSION=2.10.1 \
+    PYTHON_VERSION=3.10.16 \
+    DOCUPLOADER_VERSION=0.6.5 \
+    GH_VERSION=2.65.0 \
+    SYFT_VERSION=1.19.0
+
+ENV OLDEST_RUBY_VERSION=$RUBY_33_VERSION \
+    NEWEST_RUBY_VERSION=$RUBY_33_VERSION \
+    DEFAULT_RUBY_VERSION=$RUBY_33_VERSION \
+    RUBY_VERSIONS="$RUBY_33_VERSION"
+
+# Legacy envs we may be able to get rid of once we verify they're not used.
+ENV BUNDLER1_VERSION=1.17.3 \
+    BUNDLER2_VERSION=$BUNDLER_VERSION
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Set the locale
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends locales \
+    && apt-get -y autoremove \
+    && apt-get -y autoclean \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      apt-transport-https \
+      autoconf \
+      bison \
+      build-essential \
+      ca-certificates \
+      curl \
+      freetds-bin \
+      freetds-dev \
+      git \
+      gpg-agent \
+      imagemagick \
+      libasound2 \
+      libbz2-dev \
+      libffi-dev \
+      libgdbm-dev \
+      liblzma-dev \
+      libmagickwand-dev \
+      libmysqlclient-dev \
+      libncurses5-dev \
+      libpq-dev \
+      libreadline-dev \
+      libreadline6-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      libvips-dev \
+      libyaml-dev \
+      make \
+      memcached \
+      mysql-server \
+      pkg-config \
+      postgresql \
+      postgresql-contrib \
+      python-openssl \
+      qt5-qmake \
+      software-properties-common \
+      sqlite3 \
+      wget \
+      xz-utils \
+      zlib1g-dev \
+      jq \
+      libatk-bridge2.0-0 \
+      libdrm-dev \
+      libgbm-dev \
+      libxkbcommon-dev \
+    && apt-get -y autoremove \
+    && apt-get -y autoclean
+
+# Install docker
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce \
+    && apt-get -y autoremove \
+    && apt-get -y autoclean
+
+# Install rbenv
+ENV RBENV_ROOT=/root/.rbenv
+RUN git clone --depth=1 https://github.com/rbenv/rbenv.git $RBENV_ROOT \
+    && cd $RBENV_ROOT \
+    && src/configure \
+    && make -C src
+ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
+RUN echo 'eval "$(rbenv init -)"' >> /etc/profile
+RUN echo 'eval "$(rbenv init -)"' >> .bashrc
+RUN mkdir -p "$(rbenv root)"/plugins \
+    && git clone --depth=1 https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+
+# Install ruby
+ENV RUBY_CONFIGURE_OPTS --disable-install-doc
+RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN for version in ${RUBY_VERSIONS}; do \
+      rbenv install "$version" \
+        && rbenv global "$version" \
+        && gem update --system \
+        && gem install bundler:${BUNDLER_VERSION} \
+                       rake:${RAKE_VERSION} \
+                       toys:${TOYS_VERSION} \
+                       gems:${GEMS_VERSION} \
+                       jwt:${JWT_VERSION}; \
+    done \
+    && rbenv global ${DEFAULT_RUBY_VERSION}
+
+# Install pyenv
+ENV PYENV_ROOT=/root/.pyenv
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && cd $PYENV_ROOT \
+    && src/configure \
+    && make -C src
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc
+RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc
+RUN echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+
+# Install python
+RUN pyenv install ${PYTHON_VERSION} \
+    && pyenv global ${PYTHON_VERSION} \
+    && python3 -m pip install gcp-docuploader==${DOCUPLOADER_VERSION}
+
+# Install gh
+RUN mkdir -p /opt/local \
+    && wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz \
+    && tar xvzf gh_${GH_VERSION}_linux_amd64.tar.gz -C /opt/local/ \
+    && ln -s /opt/local/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/ \
+    && rm gh_${GH_VERSION}_linux_amd64.tar.gz
+
+# Install syft
+ADD https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.deb /workspace/syft.deb
+RUN dpkg -i /workspace/syft.deb
+
+# Install gcloud CLI
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update -y && \
+    apt-get install google-cloud-cli -y
+
+# Allow non-root users read access to /root (for Trampoline V2)
+RUN chmod -v a+rx /root


### PR DESCRIPTION
Creates a new ruby-release image based on the logic of the ruby-multi image with a few differences:

* only includes the default version of ruby (currently 3.3), but still sets relevant env vars for min/max/default
* does not include chrome or nodejs which is used for testing and compiling assets
* adds syft binary
* add gcloud CLI binary