### PR TITLE
feat: create dedicated php-release image

### DIFF
--- a/php/cloudbuild-release.yaml
+++ b/php/cloudbuild-release.yaml
@@ -33,5 +33,19 @@ steps:
     ['-i', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php81', '--config', '/workspace/php/php81.yaml', '-v']
   waitFor: ['build-php81']
 
+
+# PHP release
+- id: 'build-release'
+  name: gcr.io/cloud-builders/docker
+  args:
+    ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php-release', '.']
+  dir: 'php/release'
+  waitFor: ['-']
+- name: gcr.io/gcp-runtimes/structure_test
+  args:
+    ['-i', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php-release', '--config', '/workspace/php/release.yaml', '-v']
+  waitFor: ['build-release']
+
 images:
   - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php81
+  - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php-release

--- a/php/cloudbuild-test.yaml
+++ b/php/cloudbuild-test.yaml
@@ -58,3 +58,15 @@ steps:
     ['-i', 'gcr.io/cloud-devrel-kokoro-resources/php83', '--config', '/workspace/php/php83.yaml', '-v']
   waitFor: ['build-php83']
 
+# PHP release
+- id: 'build-php-release'
+  name: gcr.io/cloud-builders/docker
+  args:
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/release', '-t', 'gcr.io/cloud-devrel-public-resources/release', '.']
+  dir: 'php/release'
+  waitFor: ['-']
+
+- name: gcr.io/gcp-runtimes/structure_test
+  args:
+    ['-i', 'gcr.io/cloud-devrel-kokoro-resources/release', '--config', '/workspace/php/release.yaml', '-v']
+  waitFor: ['build-php-release']

--- a/php/release.yaml
+++ b/php/release.yaml
@@ -16,7 +16,7 @@ schemaVersion: 1.0.0
 commandTests:
 - name: "version"
   command: ["php", "-version"]
-  expectedOutput: ["PHP 8.1"]
+  expectedOutput: ["PHP 8.4"]
 - name: "required php extentions"
   command: ["php", "-m"]
   expectedOutput: ["grpc"]

--- a/php/release.yaml
+++ b/php/release.yaml
@@ -1,0 +1,42 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+schemaVersion: 1.0.0
+commandTests:
+- name: "version"
+  command: ["php", "-version"]
+  expectedOutput: ["PHP 8.1"]
+- name: "required php extentions"
+  command: ["php", "-m"]
+  expectedOutput: ["grpc"]
+  expectedOutput: ["sodium"]
+  expectedOutput: ["pdo_sqlsrv"]
+- name: "composer"
+  command: ["composer", "about"]
+  expectedOutput: ["Composer - Dependency Manager for PHP - version"]
+- name: "gcloud"
+  command: ["gcloud", "version"]
+  expectedOutput: ["Google Cloud SDK"]
+- name: "jq"
+  command: ["jq", "--version"]
+  expectedOutput: ["jq-"]
+- name: "uuidgen"
+  command: ["uuidgen", "--version"]
+  expectedOutput: ["uuidgen"]
+- name: "git"
+  command: ["git", "--version"]
+  expectedOutput: ["git version"]
+- name: "zip"
+  command: ["zip", "--version"]
+  expectedOutput: ["This is Zip"]

--- a/php/release/Dockerfile
+++ b/php/release/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
 ENV PHP_DIR=/opt/php81
 ENV PHP_SRC_DIR=/usr/local/src/php81-build
 ENV PATH=${PATH}:/usr/local/bin:${PHP_DIR}/bin
-ENV PHP_VERISON=8.1.18
+ENV PHP_VERISON=8.4.3
 
 RUN apt-get update && \
     apt-get -y install \

--- a/php/release/Dockerfile
+++ b/php/release/Dockerfile
@@ -1,0 +1,147 @@
+FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
+ENV PHP_DIR=/opt/php81
+ENV PHP_SRC_DIR=/usr/local/src/php81-build
+ENV PATH=${PATH}:/usr/local/bin:${PHP_DIR}/bin
+ENV PHP_VERISON=8.1.18
+
+RUN apt-get update && \
+    apt-get -y install \
+            autoconf \
+            build-essential \
+            git-core \
+            jq \
+            libbz2-dev \
+            libcurl4-openssl-dev \
+            libc-client2007e \
+            libc-client2007e-dev \
+            libfcgi-dev \
+            libfcgi0ldbl \
+            libfreetype6-dev \
+            libicu-dev \
+            libjpeg-dev \
+            libkrb5-dev \
+            libmcrypt-dev \
+            libmagickwand-dev \
+            libpng-dev \
+            libpq-dev \
+            libsodium-dev \
+            libssl-dev \
+            libxml2-dev \
+            libxslt1-dev \
+            libzip-dev \
+            unixodbc-dev \
+            php-imagick \
+            python-ipaddress \
+            wget \
+            zip \
+            zlib1g-dev \
+            pkg-config \
+            sqlite3 \
+            libsqlite3-dev \
+            libonig-dev \
+            uuid-runtime
+
+# Remove old version of PHP
+RUN apt purge -y php7.4-common
+
+RUN ln -s /usr/lib/libc-client.a /usr/lib/x86_64-linux-gnu/libc-client.a && \
+    mkdir -p ${PHP_DIR} ${PHP_SRC_DIR} ${PHP_DIR}/lib/conf.d && \
+    cd ${PHP_SRC_DIR} && \
+    wget http://us1.php.net/get/php-$PHP_VERISON.tar.bz2/from/this/mirror \
+         -O php-$PHP_VERISON.tar.bz2 && \
+    tar jxf php-$PHP_VERISON.tar.bz2 && \
+    cd php-$PHP_VERISON && \
+    ./configure \
+        --prefix=${PHP_DIR} \
+        --with-config-file-scan-dir=${PHP_DIR}/lib/conf.d \
+        --with-pdo-pgsql \
+        --with-zlib-dir \
+        --enable-mbstring \
+        --enable-soap \
+        --enable-intl \
+        --enable-calendar \
+        --with-curl \
+        --with-zlib \
+        --with-pgsql \
+        --disable-rpath \
+        --with-bz2 \
+        --with-zlib \
+        --enable-sockets \
+        --enable-sysvsem \
+        --enable-sysvshm \
+        --enable-sysvmsg \
+        --enable-pcntl \
+        --enable-mbregex \
+        --enable-exif \
+        --enable-bcmath \
+        --with-mhash \
+        --with-pdo-mysql \
+        --with-sodium=shared \
+        --with-mysqli \
+        --with-openssl \
+        --with-fpm-user=www-data \
+        --with-fpm-group=www-data \
+        --with-libdir=/lib/x86_64-linux-gnu \
+        --enable-ftp \
+        --with-imap \
+        --with-imap-ssl \
+        --with-gettext \
+        --with-xsl \
+        --with-zip \
+        --with-kerberos \
+        --enable-fpm \
+        --with-pear && \
+        make && \
+        make install && \
+        pecl install grpc pdo_sqlsrv && \
+        cp php.ini-production ${PHP_DIR}/lib/php.ini && \
+        echo 'zend_extension=opcache.so' >> ${PHP_DIR}/lib/php.ini && \
+        echo 'extension=sodium' >> ${PHP_DIR}/lib/php.ini && \
+        echo 'extension=grpc.so' >> ${PHP_DIR}/lib/conf.d/ext-grpc.ini && \
+        git clone https://github.com/Imagick/imagick /tmp/imagick && cd /tmp/imagick && phpize && ./configure && make && make install && cd - && \
+        echo 'extension=imagick.so' >> ${PHP_DIR}/lib/conf.d/ext-imagick.ini && \
+        echo 'extension=pdo_sqlsrv.so' >> ${PHP_DIR}/lib/conf.d/ext-pdo_sqlsrv.ini && \
+        php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+        php -r "if (hash_file('SHA384', 'composer-setup.php') === rtrim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+        php composer-setup.php --filename=composer --install-dir=/usr/local/bin
+
+# Install phpunit globally
+RUN composer global require phpunit/phpunit:^8.0
+
+# Install Google Cloud SDK
+RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz \
+        -o ${HOME}/google-cloud-sdk.tar.gz \
+    && tar xzf ${HOME}/google-cloud-sdk.tar.gz -C $HOME \
+    && ${HOME}/google-cloud-sdk/install.sh \
+        --usage-reporting false \
+        --path-update false \
+        --command-completion false
+
+# Install Cloud SQL proxy
+RUN wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy \
+    && chmod +x cloud_sql_proxy \
+    && mv cloud_sql_proxy /usr/local/bin
+
+# Make composer and gcloud bins available via the PATH variable
+ENV PATH="$PATH:/root/.config/composer/vendor/bin:/root/google-cloud-sdk/bin"
+
+# Configure Google Cloud SDK
+RUN gcloud config set app/promote_by_default false && \
+    gcloud config set disable_prompts true && \
+    gcloud -q components install app-engine-python && \
+    gcloud -q components update
+
+# Build php-cs-fixer
+RUN composer global require friendsofphp/php-cs-fixer
+
+# Install Python3
+RUN wget https://www.python.org/ftp/python/3.9.14/Python-3.9.14.tgz \
+    && tar -xvf Python-3.9.14.tgz \
+    && ./Python-3.9.14/configure --enable-optimizations \
+    && make altinstall
+
+# Install pip
+RUN wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
+  && python3.9 /tmp/get-pip.py \
+  && rm /tmp/get-pip.py \
+  && python3.9 -m pip


### PR DESCRIPTION
This image includes uuid-runtime for SBOM generation.

This image is based on the php-81 image which is currently used for releases (and tests). Tests do not need additional dependencies.