### PR TITLE
chore: create java8-airlock container image in the release project

### DIFF
--- a/java/cloudbuild-release.yaml
+++ b/java/cloudbuild-release.yaml
@@ -30,10 +30,21 @@ steps:
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
     id: buildx-create
     args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
-      "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8", "."]
+      "--push",
+      "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8-airlock", "."]
+    dir: java/java8-airlock
+    id: java8-airlock-build
+    waitFor: ["buildx-create"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8-airlock", "--config", "java/java8.yaml", "-v"]
+    waitFor: ["java8-airlock-build"]
+  # Java 8 build
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8", "."]
     dir: java/java8
     id: java8-build
-    waitFor: ["buildx-create"]
+    waitFor: ["-"]
   - name: gcr.io/gcp-runtimes/structure_test
     args:
       ["-i", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8", "--config", "java/java8.yaml", "-v"]
@@ -53,6 +64,7 @@ steps:
 
 images:
   - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8
+  - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8-airlock
   - us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java17
 
 options:

--- a/java/cloudbuild-release.yaml
+++ b/java/cloudbuild-release.yaml
@@ -23,13 +23,15 @@ steps:
       - --name=buildx-builder
       - --driver=docker-container
       - --driver-opt
-      - network=cloudbuild,default-load=true
+      - network=cloudbuild
       - --use
   # Java 8 Airlock build
   - name: gcr.io/cloud-builders/docker
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
     id: buildx-create
+    # https://docs.docker.com/build/builders/drivers/#loading-to-local-image-store
     args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
+      "--load",
       "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8-airlock", "."]
     dir: java/java8-airlock
     id: java8-airlock-build

--- a/java/cloudbuild-release.yaml
+++ b/java/cloudbuild-release.yaml
@@ -23,14 +23,13 @@ steps:
       - --name=buildx-builder
       - --driver=docker-container
       - --driver-opt
-      - network=cloudbuild
+      - network=cloudbuild,default-load=true
       - --use
   # Java 8 Airlock build
   - name: gcr.io/cloud-builders/docker
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
     id: buildx-create
     args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
-      "--push",
       "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8-airlock", "."]
     dir: java/java8-airlock
     id: java8-airlock-build

--- a/java/cloudbuild-release.yaml
+++ b/java/cloudbuild-release.yaml
@@ -25,7 +25,7 @@ steps:
       - --driver-opt
       - network=cloudbuild
       - --use
-  # Java 8 build
+  # Java 8 Airlock build
   - name: gcr.io/cloud-builders/docker
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
     id: buildx-create

--- a/java/cloudbuild-test.yaml
+++ b/java/cloudbuild-test.yaml
@@ -19,13 +19,14 @@ steps:
   - name: "gcr.io/cloud-builders/docker"
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
     id: buildx-create
+    # https://docs.docker.com/build/builders/drivers/#load-by-default
     args:
       - buildx
       - create
       - --name=buildx-builder
       - --driver=docker-container
       - --driver-opt
-      - network=cloudbuild
+      - network=cloudbuild,default-load=true
       - --use
   # Java 8 Airlock build
   - name: gcr.io/cloud-builders/docker
@@ -39,6 +40,10 @@ steps:
     env:
     - 'DOCKER_BUILDKIT=1'
     - 'COMPOSE_DOCKER_CLI_BUILD=1'
+  - name: gcr.io/cloud-builders/docker
+    args: ["image", "ls"]
+    id: java8-airlock-build-check
+    waitFor: ["java8-airlock-build"]
   - name: gcr.io/gcp-runtimes/structure_test
     args:
       ["-i", "java8-airlock-local", "--config", "java/java8.yaml", "-v"]

--- a/java/cloudbuild-test.yaml
+++ b/java/cloudbuild-test.yaml
@@ -19,19 +19,20 @@ steps:
   - name: "gcr.io/cloud-builders/docker"
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
     id: buildx-create
-    # https://docs.docker.com/build/builders/drivers/#load-by-default
     args:
       - buildx
       - create
       - --name=buildx-builder
       - --driver=docker-container
       - --driver-opt
-      - network=cloudbuild,default-load=true
+      - network=cloudbuild
       - --use
   # Java 8 Airlock build
   - name: gcr.io/cloud-builders/docker
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
+    # https://docs.docker.com/build/builders/drivers/#loading-to-local-image-store
     args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
+      "--load",
       "-t", "java8-airlock-local",
       "."]
     dir: java/java8-airlock

--- a/java/cloudbuild-test.yaml
+++ b/java/cloudbuild-test.yaml
@@ -31,8 +31,7 @@ steps:
   - name: gcr.io/cloud-builders/docker
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
     args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
-      "-t", "gcr.io/$PROJECT_ID/java8-airlock",
-      "-t", "gcr.io/cloud-devrel-public-resources/java8-airlock",
+      "-t", "java8-airlock-local",
       "."]
     dir: java/java8-airlock
     id: java8-airlock-build
@@ -42,7 +41,7 @@ steps:
     - 'COMPOSE_DOCKER_CLI_BUILD=1'
   - name: gcr.io/gcp-runtimes/structure_test
     args:
-      ["-i", "gcr.io/$PROJECT_ID/java8-airlock", "--config", "java/java8.yaml", "-v"]
+      ["-i", "java8-airlock-local", "--config", "java/java8.yaml", "-v"]
     waitFor: ["java8-airlock-build"]
   # Java 8 build
   - name: gcr.io/cloud-builders/docker

--- a/java/cloudbuild-test.yaml
+++ b/java/cloudbuild-test.yaml
@@ -27,31 +27,33 @@ steps:
       - --driver-opt
       - network=cloudbuild
       - --use
-  # Java 8 build
+  # Java 8 Airlock build
   - name: gcr.io/cloud-builders/docker
     # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
     args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
-      "-t", "gcr.io/$PROJECT_ID/java8",
-      "-t", "gcr.io/cloud-devrel-public-resources/java8",
+      "-t", "gcr.io/$PROJECT_ID/java8-airlock",
+      "-t", "gcr.io/cloud-devrel-public-resources/java8-airlock",
       "."]
-    dir: java/java8
-    id: java8-build
+    dir: java/java8-airlock
+    id: java8-airlock-build
     waitFor: ["buildx-create"]
     env:
     - 'DOCKER_BUILDKIT=1'
     - 'COMPOSE_DOCKER_CLI_BUILD=1'
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "gcr.io/$PROJECT_ID/java8-airlock", "--config", "java/java8.yaml", "-v"]
+    waitFor: ["java8-airlock-build"]
+  # Java 8 build
   - name: gcr.io/cloud-builders/docker
-    id: java8-buildx-ls
-    args: ["buildx", "ls"]
-    waitFor: ["java8-build"]
-  - name: gcr.io/cloud-builders/docker
-    id: java8-buildx-inspect
-    args: ["buildx", "inspect", "buildx-builder"]
-    waitFor: ["java8-buildx-ls", "java8-build"]
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java8", "."]
+    dir: java/java8
+    id: java8-build
+    waitFor: ["-"]
   - name: gcr.io/gcp-runtimes/structure_test
     args:
       ["-i", "gcr.io/$PROJECT_ID/java8", "--config", "java/java8.yaml", "-v"]
-    waitFor: ["java8-buildx-inspect", "java8-build"]
+    waitFor: ["java8-build"]
 
   # Java 11 build
   - name: gcr.io/cloud-builders/docker

--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -16,26 +16,9 @@ timeout: 7200s # 2 hours
 substitutions:
   _GRAALVM_VERSION: '22.3.3'
 steps:
-  - name: "gcr.io/cloud-builders/docker"
-    # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
-    id: buildx-create
-    args:
-      - buildx
-      - create
-      - --name=buildx-builder
-      - --driver=docker-container
-      - --driver-opt
-      - network=cloudbuild
-      - --use
   # Java 8 build
   - name: gcr.io/cloud-builders/docker
-    # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
-    # The infrastructure-public-image tag is for image scanning (b/314943422).
-    args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
-      "-t", "gcr.io/$PROJECT_ID/java8",
-      "-t", "gcr.io/cloud-devrel-public-resources/java8",
-      "-t", "gcr.io/cloud-devrel-public-resources/java8:infrastructure-public-image-$SHORT_SHA",
-      "."]
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java8", "."]
     dir: java/java8
     id: java8-build
     waitFor: ["-"]
@@ -43,6 +26,23 @@ steps:
     args:
       ["-i", "gcr.io/$PROJECT_ID/java8", "--config", "java/java8.yaml", "-v"]
     waitFor: ["java8-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "tag",
+        "gcr.io/$PROJECT_ID/java8",
+        "gcr.io/cloud-devrel-public-resources/java8",
+      ]
+  - name: gcr.io/cloud-builders/docker
+    # The tag for image scanning (b/314943422)
+    args:
+      [
+        "tag",
+        "gcr.io/$PROJECT_ID/java8",
+        "gcr.io/cloud-devrel-public-resources/java8:infrastructure-public-image-$SHORT_SHA",
+      ]
+    waitFor: ["java8-build"]
+
 
   # Java 11 build
   - name: gcr.io/cloud-builders/docker
@@ -100,7 +100,7 @@ steps:
 
     # Java 17 build
   - name: gcr.io/cloud-builders/docker
-    args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254", "-t", "gcr.io/$PROJECT_ID/java17", "."]
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/java17", "."]
     dir: java/java17
     id: java17-build
     waitFor: ["-"]

--- a/java/java8-airlock/Dockerfile
+++ b/java/java8-airlock/Dockerfile
@@ -1,0 +1,135 @@
+# Copyright 2018 Google LLCRG
+# 
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The file is copied by the previous step in Cloud Build yaml file
+# INCLUDE+ Dockerfile.ubuntu-bookworm.airlock
+
+# openjdk:8-jdk as of January 23th, 2025
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/openjdk@sha256:3af2ac94130765b73fc8f1b42ffc04f77996ed8210c297fcfa28ca880ff0a217 as mybootstrap
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y --allow-change-held-packages \
+        gnupg curl ca-certificates apt-utils && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    echo 'deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main' | tee -a /etc/apt/sources.list.d/artifact-registry.list
+
+RUN apt-get update && apt-get install apt-transport-artifact-registry
+
+# ca-certificates is required for https
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y --allow-change-held-packages \
+        ca-certificates
+
+# Remove all other apt sources, silence errors if file doesn't exist
+RUN rm -f /etc/apt/sources.list.d/* /etc/apt/sources.list
+
+# If GOOGLE_APPLICATION_CREDENTIALS is passed in docker build command use it, if not leave it unset to support GCE Metadata in CI builds
+ARG GOOGLE_APPLICATION_CREDENTIALS
+
+# You can override the repository URL with:
+# --build-arg="APT_REPO=ar+https://us-apt.pkg.dev/remote/artifact-foundry-prod/debian-3p-remote-bullseye bullseye main" .
+# This is convinient when you want to pass a special Airlock repository
+# that initiates software package imports.
+ARG APT_REPO="ar+https://us-apt.pkg.dev/projects/artifact-foundry-prod standard-debian-bullseye-3p-l1 main"
+
+# The container image is "bullseye". So use matching configuration from:
+# go/airlock/howto_debian?DEBIAN_REPOSITORY=bullseye&APT_REPOSITORY=bullseye-3p-l1#apt-debian-standard-repositories
+RUN --mount=type=secret,id=credentials \
+    echo "deb ${APT_REPO}" | \
+    tee -a  /etc/apt/sources.list.d/artifact-registry.list && \
+    apt-get update
+
+RUN --mount=type=secret,id=credentials \
+    apt install -y python3.9 python3-pip
+
+RUN python3 --version
+# Install python setuptools
+RUN python3 -m pip install setuptools
+
+# Everything after this is for your image, if you build FROM a base image with Airlock already configured
+RUN --mount=type=secret,id=credentials \
+    apt install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg
+
+ENV MAVEN_HOME=/usr/share/maven
+# 3.9.9-eclipse-temurin-11-alpine
+COPY --from=us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:d3f04985c6a68415e36c0a6468d0f8316f27d4dbee77bc459257ba444224bd9f ${MAVEN_HOME} ${MAVEN_HOME}
+
+ENV PATH $PATH:${MAVEN_HOME}/bin
+
+# jq and xmlstarlet used to modify json and xml files
+RUN --mount=type=secret,id=credentials \
+    apt-get -y install jq
+RUN --mount=type=secret,id=credentials \
+    apt-get -y install xmlstarlet
+
+# Installing JDK 11 to build projects that depend on graal-sdk 22.1.0 or higher
+# (requiring Java 11+). Still we target Java 8 for the compiled class files.
+RUN --mount=type=secret,id=credentials \
+    apt-get install -y openjdk-11-jdk
+# JDK 11 is used only when explicitly selected in the build file
+ENV JAVA8_HOME=/usr/local/openjdk-8
+ENV JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# TODO(b/390675031) The following packages are still downloading outside Airlock
+
+# Install gcloud SDK
+RUN --mount=type=secret,id=credentials \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && apt-get update -y && \
+    apt install -y google-cloud-sdk
+
+# Install google-play-services version 1
+RUN mkdir -p /tmp/playservices && \
+    wget -q https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -O /tmp/play-services-basement.aar && \
+    unzip -q /tmp/play-services-basement.aar -d /tmp/playservices && \
+    mvn -V install:install-file \
+        -Dfile=/tmp/playservices/classes.jar \
+        -DgroupId=com.google.android.google-play-services \
+        -DartifactId=google-play-services \
+        -Dversion=1 \
+        -Dpackaging=jar
+
+# Install the appengine SDK
+RUN mvn -V dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65
+
+# Adding the package path to local
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+
+# Install docker
+RUN --mount=type=secret,id=credentials \
+    apt-get update && apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        lsb-release \
+        software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install Terraform
+RUN --mount=type=secret,id=credentials \
+    apt-get update && apt-get install -y gnupg software-properties-common curl && \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+    apt-get update && apt-get install terraform
+
+
+WORKDIR /workspace

--- a/java/java8.yaml
+++ b/java/java8.yaml
@@ -37,8 +37,8 @@ commandTests:
   command: ["xmllint", "--version"]
   expectedError: ["using libxml version"]
 - name: "python"
-  command: ["python", "--version"]
-  expectedOutput: ["Python 3.9.13"]
+  command: ["python3", "--version"]
+  expectedOutput: ["Python 3.9"]
 - name: "docker"
   command: ["docker", "--version"]
   expectedOutput: ["Docker version *"]

--- a/java/java8.yaml
+++ b/java/java8.yaml
@@ -21,9 +21,6 @@ commandTests:
 - name: "maven"
   command: ["mvn", "-version"]
   expectedOutput: ["Apache Maven 3.9.*"]
-- name: "gradle"
-  command: ["gradle", "-version"]
-  expectedOutput: ["Gradle 4.9"]
 - name: "gcloud"
   command: ["gcloud", "version"]
   expectedOutput: ["Google Cloud SDK"]

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -13,78 +13,30 @@
 # limitations under the License.
 
 # openjdk:8-jdk as of January 23th, 2025
-FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/openjdk@sha256:3af2ac94130765b73fc8f1b42ffc04f77996ed8210c297fcfa28ca880ff0a217 as mybootstrap
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/openjdk@sha256:3af2ac94130765b73fc8f1b42ffc04f77996ed8210c297fcfa28ca880ff0a217
 
+# TODO(suztomo): Update this to source them from Airlock
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y --allow-change-held-packages \
-        gnupg curl ca-certificates apt-utils && \
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo 'deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main' | tee -a /etc/apt/sources.list.d/artifact-registry.list
-
-RUN apt-get update && apt-get install apt-transport-artifact-registry
-
-# ca-certificates is required for https
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y --allow-change-held-packages \
-        ca-certificates
-
-# Remove all other apt sources, silence errors if file doesn't exist
-RUN rm -f /etc/apt/sources.list.d/* /etc/apt/sources.list
-
-# If GOOGLE_APPLICATION_CREDENTIALS is passed in docker build command use it, if not leave it unset to support GCE Metadata in CI builds
-ARG GOOGLE_APPLICATION_CREDENTIALS
-
-# You can override the repository URL with:
-# --build-arg="APT_REPO=ar+https://us-apt.pkg.dev/remote/artifact-foundry-prod/debian-3p-remote-bullseye bullseye main" .
-# This is convinient when you want to pass a special Airlock repository
-# that initiates software package imports.
-ARG APT_REPO="ar+https://us-apt.pkg.dev/projects/artifact-foundry-prod standard-debian-bullseye-3p-l1 main"
-
-# The container image is "bullseye". So use matching configuration from:
-# go/airlock/howto_debian?DEBIAN_REPOSITORY=bullseye&APT_REPOSITORY=bullseye-3p-l1#apt-debian-standard-repositories
-RUN --mount=type=secret,id=credentials \
-    echo "deb ${APT_REPO}" | \
-    tee -a  /etc/apt/sources.list.d/artifact-registry.list && \
-    apt-get update
-
-RUN --mount=type=secret,id=credentials \
-    apt install -y python3.9 python3-pip
-
-RUN python3 --version
-# Install python setuptools
-RUN python3 -m pip install setuptools
-
-# Everything after this is for your image, if you build FROM a base image with Airlock already configured
-RUN --mount=type=secret,id=credentials \
-    apt install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg
+    apt-get -y upgrade && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
+    rm -rf /var/cache/apt
 
 ENV MAVEN_HOME=/usr/share/maven
 # 3.9.9-eclipse-temurin-11-alpine
 COPY --from=us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@sha256:d3f04985c6a68415e36c0a6468d0f8316f27d4dbee77bc459257ba444224bd9f ${MAVEN_HOME} ${MAVEN_HOME}
 
-ENV PATH $PATH:${MAVEN_HOME}/bin
+# TODO(suztomo): Do we use Gradle?
+RUN wget -q https://services.gradle.org/distributions/gradle-4.9-bin.zip -O /tmp/gradle.zip && \
+    mkdir -p /usr/local/lib/gradle && \
+    unzip -q /tmp/gradle.zip -d /usr/local/lib/gradle && \
+    rm /tmp/gradle.zip
 
-# jq and xmlstarlet used to modify json and xml files
-RUN --mount=type=secret,id=credentials \
-    apt-get -y install jq
-RUN --mount=type=secret,id=credentials \
-    apt-get -y install xmlstarlet
-
-# Installing JDK 11 to build projects that depend on graal-sdk 22.1.0 or higher
-# (requiring Java 11+). Still we target Java 8 for the compiled class files.
-RUN --mount=type=secret,id=credentials \
-    apt-get install -y openjdk-11-jdk
-# JDK 11 is used only when explicitly selected in the build file
-ENV JAVA8_HOME=/usr/local/openjdk-8
-ENV JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-
-# TODO(b/390675031) The following packages are still downloading outside Airlock
+ENV PATH $PATH:${MAVEN_HOME}/bin:/usr/local/lib/gradle/gradle-4.9/bin
 
 # Install gcloud SDK
-RUN --mount=type=secret,id=credentials \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && apt-get update -y && \
-    apt install -y google-cloud-sdk
+    apt-get install google-cloud-sdk -y
 
 # Install google-play-services version 1
 RUN mkdir -p /tmp/playservices && \
@@ -103,9 +55,26 @@ RUN mvn -V dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
+# Install pyenv
+RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+
+ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/shims:$PATH
+
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc && \
+    echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc && \
+    echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+# Install python
+RUN pyenv install 3.9.13 && \
+    pyenv global 3.9.13 && \
+    python3 -m pip install --upgrade pip setuptools
+
 # Install docker
-RUN --mount=type=secret,id=credentials \
-    apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
         apt-transport-https \
         ca-certificates \
         curl \
@@ -121,11 +90,20 @@ RUN --mount=type=secret,id=credentials \
     apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Install Terraform
-RUN --mount=type=secret,id=credentials \
-    apt-get update && apt-get install -y gnupg software-properties-common curl && \
+RUN apt-get update && apt-get install -y gnupg software-properties-common curl && \
     curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
     apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
     apt-get update && apt-get install terraform
 
+# jq and xmlstarlet used to modify json and xml files
+RUN apt-get -y install jq
+RUN apt-get -y install xmlstarlet
+
+# Installing JDK 11 to build projects that depend on graal-sdk 22.1.0 or higher
+# (requiring Java 11+). Still we target Java 8 for the compiled class files.
+RUN apt-get install -y openjdk-11-jdk
+# JDK 11 is used only when explicitly selected in the build file
+ENV JAVA8_HOME=/usr/local/openjdk-8
+ENV JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 WORKDIR /workspace


### PR DESCRIPTION
Creating a separate Dockerfile for Airlock-confirmation to avoid disruption in releases. I reverted java/java8/Dockerfile and java/cloudbuild.yaml to the state before https://github.com/googleapis/testing-infra-docker/pull/435.

The "--load" was missing in the "docker buildx" command in the previous commit in java/cloudbuild-release.yaml. This resulted in Cloud Build not uploading the container image to Artifact Registry.
