### PR TITLE
feat(ruby): Update Ruby multi image to include gcloud cli and release image to remove some unnecessary cruft

### DIFF
--- a/ruby/multi/Dockerfile
+++ b/ruby/multi/Dockerfile
@@ -21,8 +21,6 @@ ENTRYPOINT /bin/bash
 #   update it to 1.3.0 once we drop Ruby 3.0 support.
 # * The bundler gem is pinned to 2.5.23 because 2.6 requires Ruby 3.1. We can
 #   update it to 2.6 once we drop Ruby 3.0 support.
-# * The google_auth Python package is pinned to 2.37.0 because of a JWT
-#   signature in 2.38.0.
 ENV RUBY_30_VERSION=3.0.7 \
     RUBY_31_VERSION=3.1.6 \
     RUBY_32_VERSION=3.2.6 \
@@ -36,7 +34,6 @@ ENV RUBY_30_VERSION=3.0.7 \
     PYTHON_VERSION=3.10.16 \
     NODEJS_VERSION=18.20.6 \
     DOCUPLOADER_VERSION=0.6.5 \
-    PYTHON_AUTH_VERSION=2.37.0 \
     GH_VERSION=2.65.0
 
 ENV OLDEST_RUBY_VERSION=$RUBY_30_VERSION \
@@ -157,7 +154,6 @@ RUN echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 # Install python
 RUN pyenv install ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION} \
-    && python3 -m pip install google_auth==${PYTHON_AUTH_VERSION} \
     && python3 -m pip install gcp-docuploader==${DOCUPLOADER_VERSION}
 
 # Install nodenv
@@ -204,6 +200,12 @@ RUN mkdir -p /opt/local \
     && tar xvzf gh_${GH_VERSION}_linux_amd64.tar.gz -C /opt/local/ \
     && ln -s /opt/local/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/ \
     && rm gh_${GH_VERSION}_linux_amd64.tar.gz
+
+# Install gcloud CLI
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update -y && \
+    apt-get install google-cloud-cli -y
 
 # Allow non-root users read access to /root (for Trampoline V2)
 RUN chmod -v a+rx /root

--- a/ruby/release/Dockerfile
+++ b/ruby/release/Dockerfile
@@ -16,30 +16,16 @@ FROM ubuntu:focal
 
 ENTRYPOINT /bin/bash
 
-# Version notes:
-# * The gems gem is pinned to 1.2.0 because 1.3.0 requires Ruby 3.1. We can
-#   update it to 1.3.0 once we drop Ruby 3.0 support.
-# * The bundler gem is pinned to 2.5.23 because 2.6 requires Ruby 3.1. We can
-#   update it to 2.6 once we drop Ruby 3.0 support.
-ENV RUBY_33_VERSION=3.3.7 \
-    BUNDLER_VERSION=2.5.23 \
+ENV RUBY_VERSION=3.3.7 \
+    BUNDLER_VERSION=2.6.3 \
     RAKE_VERSION=13.2.1 \
     TOYS_VERSION=0.15.6 \
-    GEMS_VERSION=1.2.0 \
+    GEMS_VERSION=1.3.0 \
     JWT_VERSION=2.10.1 \
     PYTHON_VERSION=3.10.16 \
     DOCUPLOADER_VERSION=0.6.5 \
     GH_VERSION=2.65.0 \
     SYFT_VERSION=1.19.0
-
-ENV OLDEST_RUBY_VERSION=$RUBY_33_VERSION \
-    NEWEST_RUBY_VERSION=$RUBY_33_VERSION \
-    DEFAULT_RUBY_VERSION=$RUBY_33_VERSION \
-    RUBY_VERSIONS="$RUBY_33_VERSION"
-
-# Legacy envs we may be able to get rid of once we verify they're not used.
-ENV BUNDLER1_VERSION=1.17.3 \
-    BUNDLER2_VERSION=$BUNDLER_VERSION
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -64,28 +50,21 @@ RUN apt-get update \
       freetds-dev \
       git \
       gpg-agent \
-      imagemagick \
       libasound2 \
       libbz2-dev \
       libffi-dev \
       libgdbm-dev \
       liblzma-dev \
-      libmagickwand-dev \
-      libmysqlclient-dev \
       libncurses5-dev \
       libpq-dev \
       libreadline-dev \
       libreadline6-dev \
-      libsqlite3-dev \
       libssl-dev \
       libvips-dev \
       libyaml-dev \
       make \
       memcached \
-      mysql-server \
       pkg-config \
-      postgresql \
-      postgresql-contrib \
       python-openssl \
       qt5-qmake \
       software-properties-common \
@@ -124,17 +103,14 @@ RUN mkdir -p "$(rbenv root)"/plugins \
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
-RUN for version in ${RUBY_VERSIONS}; do \
-      rbenv install "$version" \
-        && rbenv global "$version" \
-        && gem update --system \
-        && gem install bundler:${BUNDLER_VERSION} \
-                       rake:${RAKE_VERSION} \
-                       toys:${TOYS_VERSION} \
-                       gems:${GEMS_VERSION} \
-                       jwt:${JWT_VERSION}; \
-    done \
-    && rbenv global ${DEFAULT_RUBY_VERSION}
+RUN rbenv install "${RUBY_VERSION}" \
+    && rbenv global "${RUBY_VERSION}" \
+    && gem update --system \
+    && gem install bundler:${BUNDLER_VERSION} \
+                   rake:${RAKE_VERSION} \
+                   toys:${TOYS_VERSION} \
+                   gems:${GEMS_VERSION} \
+                   jwt:${JWT_VERSION}
 
 # Install pyenv
 ENV PYENV_ROOT=/root/.pyenv


### PR DESCRIPTION
Specific updates:

* Multi image: Unpin google_auth python package because it wasn't to blame for earlier docuploader issues
* Multi image: Install gcloud CLI which we will use instead of the gcp_docuploader python package in the future
* New release image: Update gems and bundler gems to the latest since we're not limited by Ruby 3.0 compatibility
* New release image: Removed a bunch of unneeded environment variables
* New release image: Removed a bunch of unneeded packages related to testing databases and images
* New release image: Simplified Ruby install command since we're installing only a single Ruby version
