### PR TITLE
feat: add uuid tools to go release image

### DIFF
--- a/go/go124-release.yaml
+++ b/go/go124-release.yaml
@@ -26,3 +26,12 @@ commandTests:
   - name: "jq"
     command: ["jq", "--version"]
     expectedOutput: ["jq-"]
+  - name: "uuidgen"
+    command: ["uuidgen", "--version"]
+    expectedOutput: ["uuidgen"]
+  - name: "git"
+    command: ["git", "--version"]
+    expectedOutput: ["git version"]
+  - name: "zip"
+    command: ["zip", "--version"]
+    expectedOutput: ["This is Zip"]

--- a/go/go124-release/Dockerfile
+++ b/go/go124-release/Dockerfile
@@ -20,7 +20,9 @@ RUN set -ex; \
     apt-get install -y \
     unzip wget vim jq zip \
     # for docker
-    ca-certificates curl gnupg
+    ca-certificates curl gnupg \
+    # for SBOM generation
+    uuid-runtime
 
 RUN install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \


### PR DESCRIPTION
uuidgen is needed for SBOM generation

test: add assertions that `zip` and `git` are also installed