### PR TITLE
fix(ruby): Remove no several longer needed packages from Ruby release image, including the Python installation

### DIFF
--- a/ruby/multi/Dockerfile
+++ b/ruby/multi/Dockerfile
@@ -23,18 +23,17 @@ ENTRYPOINT /bin/bash
 #   update it to 2.6 once we drop Ruby 3.0 support.
 ENV RUBY_30_VERSION=3.0.7 \
     RUBY_31_VERSION=3.1.6 \
-    RUBY_32_VERSION=3.2.6 \
+    RUBY_32_VERSION=3.2.7 \
     RUBY_33_VERSION=3.3.7 \
-    RUBY_34_VERSION=3.4.1 \
+    RUBY_34_VERSION=3.4.2 \
     BUNDLER_VERSION=2.5.23 \
     RAKE_VERSION=13.2.1 \
     TOYS_VERSION=0.15.6 \
     GEMS_VERSION=1.2.0 \
     JWT_VERSION=2.10.1 \
     PYTHON_VERSION=3.10.16 \
-    NODEJS_VERSION=18.20.6 \
-    DOCUPLOADER_VERSION=0.6.5 \
-    GH_VERSION=2.65.0
+    NODEJS_VERSION=18.20.7 \
+    GH_VERSION=2.67.0
 
 ENV OLDEST_RUBY_VERSION=$RUBY_30_VERSION \
     NEWEST_RUBY_VERSION=$RUBY_33_VERSION \
@@ -153,8 +152,7 @@ RUN echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 # Install python
 RUN pyenv install ${PYTHON_VERSION} \
-    && pyenv global ${PYTHON_VERSION} \
-    && python3 -m pip install gcp-docuploader==${DOCUPLOADER_VERSION}
+    && pyenv global ${PYTHON_VERSION}
 
 # Install nodenv
 ENV NODENV_ROOT=/root/.nodenv

--- a/ruby/release.yaml
+++ b/ruby/release.yaml
@@ -20,12 +20,9 @@ commandTests:
   - name: "syft version"
     command: ["syft", "--version"]
     expectedOutput: ["syft 1.19.0"]
-  - name: "python version"
-    command: ["python3", "--version"]
-    expectedOutput: ["Python 3.10.16"]
   - name: "gcloud version"
     command: ["gcloud", "version"]
     expectedOutput: ["Google Cloud SDK"]
   - name: "gh version"
     command: ["gh", "--version"]
-    expectedOutput: ["gh version 2.65.0"]
+    expectedOutput: ["gh version 2.67.0"]

--- a/ruby/release/Dockerfile
+++ b/ruby/release/Dockerfile
@@ -17,14 +17,12 @@ FROM ubuntu:focal
 ENTRYPOINT /bin/bash
 
 ENV RUBY_VERSION=3.3.7 \
-    BUNDLER_VERSION=2.6.3 \
+    BUNDLER_VERSION=2.6.5 \
     RAKE_VERSION=13.2.1 \
     TOYS_VERSION=0.15.6 \
     GEMS_VERSION=1.3.0 \
     JWT_VERSION=2.10.1 \
-    PYTHON_VERSION=3.10.16 \
-    DOCUPLOADER_VERSION=0.6.5 \
-    GH_VERSION=2.65.0 \
+    GH_VERSION=2.67.0 \
     SYFT_VERSION=1.19.0
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -56,7 +54,6 @@ RUN apt-get update \
       libgdbm-dev \
       liblzma-dev \
       libncurses5-dev \
-      libpq-dev \
       libreadline-dev \
       libreadline6-dev \
       libssl-dev \
@@ -65,10 +62,8 @@ RUN apt-get update \
       make \
       memcached \
       pkg-config \
-      python-openssl \
       qt5-qmake \
       software-properties-common \
-      sqlite3 \
       wget \
       xz-utils \
       zlib1g-dev \
@@ -111,22 +106,6 @@ RUN rbenv install "${RUBY_VERSION}" \
                    toys:${TOYS_VERSION} \
                    gems:${GEMS_VERSION} \
                    jwt:${JWT_VERSION}
-
-# Install pyenv
-ENV PYENV_ROOT=/root/.pyenv
-RUN git clone --depth=1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
-    && cd $PYENV_ROOT \
-    && src/configure \
-    && make -C src
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> .bashrc
-RUN echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> .bashrc
-RUN echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-
-# Install python
-RUN pyenv install ${PYTHON_VERSION} \
-    && pyenv global ${PYTHON_VERSION} \
-    && python3 -m pip install gcp-docuploader==${DOCUPLOADER_VERSION}
 
 # Install gh
 RUN mkdir -p /opt/local \


### PR DESCRIPTION
The Ruby release script has reimplemented docuploader using a few lines of Ruby and a call to gcloud, and no longer needs Python or the gcp_docuploader package. In the new release image, I removed both, but I left Python itself in the multi image used for testing because I haven't yet verified that none of the tests (especially those in ruby-docs-samples) use Python for anything else.

Also removed a few debian packages from the release image that I'm pretty confident are never needed for releases, and updated various things to the latest versions.