### PR TITLE
feat: add jq to python-multi image

### DIFF
--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
     gpg-agent \
     graphviz \
     hunspell-en-us \
+    jq \
     libbz2-dev \
     libdb5.3-dev \
     libenchant-2-2 \


### PR DESCRIPTION
Towards b/390135527. `jq` is needed for publishing docs.