### PR TITLE
fix: java8-airlock stop installing Terraform and Docker

### DIFF
--- a/java/cloudbuild-test.yaml
+++ b/java/cloudbuild-test.yaml
@@ -47,7 +47,7 @@ steps:
     waitFor: ["java8-airlock-build"]
   - name: gcr.io/gcp-runtimes/structure_test
     args:
-      ["-i", "java8-airlock-local", "--config", "java/java8.yaml", "-v"]
+      ["-i", "java8-airlock-local", "--config", "java/java8-airlock.yaml", "-v"]
     waitFor: ["java8-airlock-build"]
   # Java 8 build
   - name: gcr.io/cloud-builders/docker

--- a/java/java8-airlock.yaml
+++ b/java/java8-airlock.yaml
@@ -1,0 +1,29 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+schemaVersion: 1.0.0
+commandTests:
+- name: "version"
+  command: ["java", "-version"]
+  # java -version outputs to stderr...
+  expectedError: ["(java|openjdk) version \"1.8.*\""]
+- name: "maven"
+  command: ["mvn", "-version"]
+  expectedOutput: ["Apache Maven 3.9.*"]
+- name: "gcloud"
+  command: ["gcloud", "version"]
+  expectedOutput: ["Google Cloud SDK"]
+- name: "xmllint tool"
+  command: ["xmllint", "--version"]
+  expectedError: ["using libxml version"]

--- a/java/java8-airlock/Dockerfile
+++ b/java/java8-airlock/Dockerfile
@@ -90,6 +90,9 @@ RUN --mount=type=secret,id=credentials \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && apt-get update -y && \
     apt install -y google-cloud-sdk
 
+# Adding the package path to local
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+
 # Install google-play-services version 1
 RUN mkdir -p /tmp/playservices && \
     wget -q https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/8.3.0/play-services-basement-8.3.0.aar -O /tmp/play-services-basement.aar && \
@@ -100,36 +103,5 @@ RUN mkdir -p /tmp/playservices && \
         -DartifactId=google-play-services \
         -Dversion=1 \
         -Dpackaging=jar
-
-# Install the appengine SDK
-RUN mvn -V dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65
-
-# Adding the package path to local
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
-
-# Install docker
-RUN --mount=type=secret,id=credentials \
-    apt-get update && apt-get install -y \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg-agent \
-        lsb-release \
-        software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/debian \
-        $(lsb_release -cs) \
-        stable" && \
-    apt-get update && \
-    apt-get install -y docker-ce docker-ce-cli containerd.io
-
-# Install Terraform
-RUN --mount=type=secret,id=credentials \
-    apt-get update && apt-get install -y gnupg software-properties-common curl && \
-    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
-    apt-get update && apt-get install terraform
-
 
 WORKDIR /workspace


### PR DESCRIPTION
Terraform and Docker are not needed for the release jobs. cl/734604020

b/356854847
