### PR TITLE
set minimum rubygems-update to ensure gem update --system runs when ruby version deprecated

### DIFF
--- a/ruby/multi/Dockerfile
+++ b/ruby/multi/Dockerfile
@@ -21,11 +21,15 @@ ENTRYPOINT /bin/bash
 #   update it to 1.3.0 once we drop Ruby 3.0 support.
 # * The bundler gem is pinned to 2.5.23 because 2.6 requires Ruby 3.1. We can
 #   update it to 2.6 once we drop Ruby 3.0 support.
+# * The rubygems-update gem is pinned to 3.5.4 because this version introduced
+#   a fix to ensure the 'gem update --system' command respects ruby version
+#   constraints. b/410431197
 ENV RUBY_30_VERSION=3.0.7 \
     RUBY_31_VERSION=3.1.6 \
     RUBY_32_VERSION=3.2.7 \
     RUBY_33_VERSION=3.3.7 \
     RUBY_34_VERSION=3.4.2 \
+    GEMSUPDATE_VERSION=3.5.4 \
     BUNDLER_VERSION=2.5.23 \
     RAKE_VERSION=13.2.1 \
     TOYS_VERSION=0.15.6 \
@@ -131,6 +135,7 @@ RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN for version in ${RUBY_VERSIONS}; do \
       rbenv install "$version" \
         && rbenv global "$version" \
+        && gem install rubygems-update -v ${GEMSUPDATE_VERSION} \
         && gem update --system \
         && gem install bundler:${BUNDLER_VERSION} \
                        rake:${RAKE_VERSION} \


### PR DESCRIPTION
Identified in https://github.com/GoogleCloudPlatform/ruby-docs-samples/issues/1553

Internal b/410431197

[rubygems-update 3.5.4](https://togithub.com/rubygems/rubygems/releases/tag/v3.5.4) introduced a fix to ensure the ruby version constraints are adhered to when running `gem update --system`. This version of rubygems-update isn't made available in the ruby source (used by rbenv) until Ruby 3.3.1(the next Ruby release after this update)

This change ensures that the gem used to run `gem update --system` is updated to at least a version that considers Ruby versions before updating to the most _valid_ up to date version. 

Without this change, trying to build ruby images where the latest rubygems-updates drops ruby support will silently fail (due to the `gem update --system` failing in a for loop in a dockerfile `RUN` line not causing the entire build to fail) (will happen until the minimum version is 3.3.1+, at least two years from now, between the window of rubygems dropping support and us dropping support) (logs in b/410431197)
