### PR TITLE
fix(java): the Java containers to have zip for bundle files 

### DIFF
--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -16,7 +16,7 @@ FROM openjdk:11-jdk
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip && \
     rm -rf /var/cache/apt
 
 RUN wget -q https://archive.apache.org/dist/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip -O /tmp/maven.zip && \

--- a/java/java11/Dockerfile
+++ b/java/java11/Dockerfile
@@ -16,7 +16,7 @@ FROM openjdk:11-jdk
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip unzip && \
     rm -rf /var/cache/apt
 
 RUN wget -q https://archive.apache.org/dist/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip -O /tmp/maven.zip && \

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get install wget && \
     apt-get install unzip && \
     apt -y install git && \
-    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip && \
     rm -rf /var/cache/apt
 
 ENV MAVEN_HOME=/usr/share/maven

--- a/java/java17/Dockerfile
+++ b/java/java17/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get install wget && \
     apt-get install unzip && \
     apt -y install git && \
-    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip unzip && \
     rm -rf /var/cache/apt
 
 ENV MAVEN_HOME=/usr/share/maven

--- a/java/java21/Dockerfile
+++ b/java/java21/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get install wget && \
     apt-get install unzip && \
     apt -y install git && \
-    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip unzip && \
     rm -rf /var/cache/apt
 
 RUN wget -q https://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip -O /tmp/maven.zip && \

--- a/java/java8-airlock/Dockerfile
+++ b/java/java8-airlock/Dockerfile
@@ -60,7 +60,7 @@ RUN python3 -m pip install setuptools
 
 # Everything after this is for your image, if you build FROM a base image with Airlock already configured
 RUN --mount=type=secret,id=credentials \
-    apt install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg
+    apt install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip
 
 ENV MAVEN_HOME=/usr/share/maven
 # 3.9.9-eclipse-temurin-11-alpine

--- a/java/java8-airlock/Dockerfile
+++ b/java/java8-airlock/Dockerfile
@@ -60,7 +60,7 @@ RUN python3 -m pip install setuptools
 
 # Everything after this is for your image, if you build FROM a base image with Airlock already configured
 RUN --mount=type=secret,id=credentials \
-    apt install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip
+    apt install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip unzip
 
 ENV MAVEN_HOME=/usr/share/maven
 # 3.9.9-eclipse-temurin-11-alpine

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -18,7 +18,7 @@ FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/openjdk@sha256:3a
 # TODO(suztomo): Update this to source them from Airlock
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip unzip && \
     rm -rf /var/cache/apt
 
 ENV MAVEN_HOME=/usr/share/maven

--- a/java/java8/Dockerfile
+++ b/java/java8/Dockerfile
@@ -18,7 +18,7 @@ FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/openjdk@sha256:3a
 # TODO(suztomo): Update this to source them from Airlock
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg && \
+    apt-get install -y --no-install-recommends libxml2-utils apt-transport-https ca-certificates gnupg zip && \
     rm -rf /var/cache/apt
 
 ENV MAVEN_HOME=/usr/share/maven


### PR DESCRIPTION
The Central Portal API uses a bundle format, which is a zip file.
