### PR TITLE
fix: update node18-user to Debian bookworm

### DIFF
--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:18-buster
+FROM node:18-bookworm
 
 # Add Graphviz
 RUN set -ex; \
@@ -29,13 +29,25 @@ RUN set -ex; \
   rm -rf /var/lib/apt/lists/*
 
 # Install docker
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/debian \
-        $(lsb_release -cs) \
-        stable" && \
-    apt-get update && \
-    apt-get install -y docker-ce docker-ce-cli containerd.io
+#RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+#    add-apt-repository \
+#        "deb [arch=amd64] https://download.docker.com/linux/debian \
+#        $(lsb_release -cs) \
+#        stable" && \
+#    apt-get update && \
+#    apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install docker
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update -y && \
+    apt-get install -y  docker-ce docker-ce-cli containerd.io
+
 
 # Setup protoc
 RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_64.zip > /tmp/protoc-3.10.1-linux-x86_64.zip && \
@@ -46,7 +58,7 @@ RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.10.
 # Install pyenv dependencies
 RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
 
 USER node
 

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -28,14 +28,6 @@ RUN set -ex; \
     ; \
   rm -rf /var/lib/apt/lists/*
 
-# Install docker
-#RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-#    add-apt-repository \
-#        "deb [arch=amd64] https://download.docker.com/linux/debian \
-#        $(lsb_release -cs) \
-#        stable" && \
-#    apt-get update && \
-#    apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Install docker
 RUN install -m 0755 -d /etc/apt/keyrings && \
@@ -78,8 +70,8 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
 ENV PATH="/home/node/.pyenv/bin:/home/node/.pyenv/shims:${PATH}"
 
 # Install python
-RUN pyenv install 3.10.13 && \
-    pyenv global 3.10.13 && \
+RUN pyenv install 3.12.10 && \
+    pyenv global 3.12.10 && \
     python3 -m pip install --upgrade pip setuptools
 
 # Install gcp-uploader and gcp-releasetool and their dependencies.
@@ -88,7 +80,7 @@ RUN python3 -m pip install --require-hashes -r requirements.txt
 
 # Setup Cloud SDK
 WORKDIR /home/node
-ENV CLOUD_SDK_VERSION=446.0.0 \
+ENV CLOUD_SDK_VERSION=520.0.0 \
     CLOUDSDK_PYTHON=/home/node/.pyenv/shims/python3 \
     PATH=/home/node/google-cloud-sdk/bin:$PATH
 RUN set -ex; \


### PR DESCRIPTION
In order to resolves issues updating the version of gapic-showcase used in node gax, I am updating this image. [Context](https://yaqs.corp.google.com/eng/q/8562340148677705728) (internal-only link)

**Updates that MUST stay to fix thing**
- updating the debian version (though I think we can go to one prior and still be OK)
- updating the way we install docker (this is just in line with the latest docker instructions)
- switching the name of the package to `python3-ssl`

**Updates I'm open to reverting, I just updated while I was in there**
- updating the python version
- updating the gcloud version

Full disclosure: When I ran the test-application locally it passed, but I could not successfully run the system-tests locally for gax because I couldn't locally get the secrets populated properly 