### PR TITLE
feat: add cloudbuild for syft airlock image

### DIFF
--- a/syft/airlock/cloudbuild.yaml
+++ b/syft/airlock/cloudbuild.yaml
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 7200s  # 2 hours
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
+  id: buildx-create
+  args:
+    - buildx
+    - create
+    - --name=buildx-builder
+    - --driver=docker-container
+    - --driver-opt
+    - network=cloudbuild
+    - --use
+- name: gcr.io/cloud-builders/docker
+  # go/airlock/howto_docker#example-gcb-dockerfile-in-docker-build-support
+  id: buildx-create
+  # https://docs.docker.com/build/builders/drivers/#loading-to-local-image-store
+  args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
+    "--load",
+    "-t", "us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}", "."]
+  dir: '${_IMAGE_SOURCE_PATH}'
+  id: '${_IMAGE_NAME}'
+  waitFor: ["buildx-create"]
+options:
+  machineType: 'E2_HIGHCPU_8'
+  requestedVerifyOption: VERIFIED  # For provenance attestation generation
+images:
+  - us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}


### PR DESCRIPTION
b/407529434#comment4

Referenced https://github.com/googleapis/testing-infra-docker/blob/main/java/cloudbuild-release.yaml#L21 that @suztomo pointed out.