### PR TITLE
feat(ruby): Include release scripts in Ruby release image

### DIFF
--- a/ruby/cloudbuild-release.yaml
+++ b/ruby/cloudbuild-release.yaml
@@ -15,12 +15,14 @@
 timeout: 7200s  # 2 hours
 steps:
 
-# Build Ruby multi-use image
+# Build Ruby multi-use image (used for integration tests)
 - id: 'build-multi'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-multi', '.']
   dir: 'ruby/multi'
   waitFor: ['-']
+
+# Build Ruby release image
 - id: 'build-release'
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-release', '.']

--- a/ruby/release.yaml
+++ b/ruby/release.yaml
@@ -16,7 +16,13 @@ schemaVersion: 1.0.0
 commandTests:
   - name: "ruby version"
     command: ["ruby", "-v"]
-    expectedOutput: ["ruby 3.3.7"]
+    expectedOutput: ["ruby 3.4.4"]
+  - name: "toys version"
+    command: ["toys", "--version"]
+    expectedOutput: ["0.15.6"]
+  - name: "toys release check"
+    command: ["toys", "system", "tools", "show", "release", "perform"]
+    expectedOutput: ["runnable: true"]
   - name: "syft version"
     command: ["syft", "--version"]
     expectedOutput: ["syft 1.19.0"]
@@ -25,4 +31,4 @@ commandTests:
     expectedOutput: ["Google Cloud SDK"]
   - name: "gh version"
     command: ["gh", "--version"]
-    expectedOutput: ["gh version 2.67.0"]
+    expectedOutput: ["gh version 2.72.0"]

--- a/ruby/release/.toys.rb
+++ b/ruby/release/.toys.rb
@@ -1,0 +1,19 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if ENV["RUBY_COMMON_TOOLS"]
+  tool "release" do
+    load File.join(ENV["RUBY_COMMON_TOOLS"], "toys", "release")
+  end
+end

--- a/ruby/release/Dockerfile
+++ b/ruby/release/Dockerfile
@@ -12,17 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:focal
+FROM ubuntu:noble
 
 ENTRYPOINT /bin/bash
 
-ENV RUBY_VERSION=3.3.7 \
-    BUNDLER_VERSION=2.6.5 \
+ENV RUBY_VERSION=3.4.4 \
+    RUBYGEMS_VERSION=3.6.9 \
+    BUNDLER_VERSION=2.6.9 \
     RAKE_VERSION=13.2.1 \
     TOYS_VERSION=0.15.6 \
     GEMS_VERSION=1.3.0 \
     JWT_VERSION=2.10.1 \
-    GH_VERSION=2.67.0 \
+    YARD_VERSION=0.9.37 \
+    REDCARPET_VERSION=3.6.1 \
+    GH_VERSION=2.72.0 \
     SYFT_VERSION=1.19.0
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -44,11 +47,8 @@ RUN apt-get update \
       build-essential \
       ca-certificates \
       curl \
-      freetds-bin \
-      freetds-dev \
       git \
       gpg-agent \
-      libasound2 \
       libbz2-dev \
       libffi-dev \
       libgdbm-dev \
@@ -57,21 +57,14 @@ RUN apt-get update \
       libreadline-dev \
       libreadline6-dev \
       libssl-dev \
-      libvips-dev \
       libyaml-dev \
       make \
-      memcached \
       pkg-config \
       qt5-qmake \
       software-properties-common \
       wget \
       xz-utils \
       zlib1g-dev \
-      jq \
-      libatk-bridge2.0-0 \
-      libdrm-dev \
-      libgbm-dev \
-      libxkbcommon-dev \
     && apt-get -y autoremove \
     && apt-get -y autoclean
 
@@ -85,10 +78,7 @@ RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubunt
 
 # Install rbenv
 ENV RBENV_ROOT=/root/.rbenv
-RUN git clone --depth=1 https://github.com/rbenv/rbenv.git $RBENV_ROOT \
-    && cd $RBENV_ROOT \
-    && src/configure \
-    && make -C src
+RUN git clone --depth=1 https://github.com/rbenv/rbenv.git $RBENV_ROOT
 ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 RUN echo 'eval "$(rbenv init -)"' >> /etc/profile
 RUN echo 'eval "$(rbenv init -)"' >> .bashrc
@@ -100,12 +90,15 @@ ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN rbenv install "${RUBY_VERSION}" \
     && rbenv global "${RUBY_VERSION}" \
-    && gem update --system \
+    && gem update --system ${RUBYGEMS_VERSION} \
     && gem install bundler:${BUNDLER_VERSION} \
                    rake:${RAKE_VERSION} \
                    toys:${TOYS_VERSION} \
                    gems:${GEMS_VERSION} \
-                   jwt:${JWT_VERSION}
+                   jwt:${JWT_VERSION} \
+                   yard:${YARD_VERSION} \
+                   redcarpet:${REDCARPET_VERSION} \
+    && rbenv rehash
 
 # Install gh
 RUN mkdir -p /opt/local \
@@ -124,5 +117,13 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     apt-get update -y && \
     apt-get install google-cloud-cli -y
 
+# Library release tooling uses the RUBY_COMMON_TOOLS environment variable to
+# specify where the ruby-common-tools repo is located.
+ENV RUBY_COMMON_TOOLS /root/ruby-common-tools
+RUN git clone --depth=1 https://github.com/googleapis/ruby-common-tools.git ${RUBY_COMMON_TOOLS}
+COPY .toys.rb /root/.toys.rb
+
 # Allow non-root users read access to /root (for Trampoline V2)
 RUN chmod -v a+rx /root
+
+WORKDIR /root


### PR DESCRIPTION
Previously, the Ruby release scripts would need to download three pieces of software from the internet during the release process: The release scripts (downloaded from https://github.com/googleapis/ruby-common-tools), and the gems `yard` and `redcarpet`. The primary purpose of this update is to vendor these items into the image itself, to reduce the risk of getting bad software, and to reduce release failures due to failure of those downloads. See internal issue b/417281463.

Details:

* Updated Ubuntu to Noble (24.04)
* Updated Ruby to 3.4.4
* Updated RubyGems to 3.6.9
* Updated Bundler to 2.6.9
* Updated GH to 2.72.0
* Installed Yard 0.9.37 into the image
* Installed Redcarpet 3.6.1 into the image
* Cloned ruby-common-tools into the image to bring in the release scripts
* Removed a bunch of unused libraries
* Removed deprecated steps from rbenv install procedure
* Added tests to ensure toys and the release scripts are present

Note the image now sets the `RUBY_COMMON_TOOLS` environment variable, which is already expected by repositories to point to the directory where the ruby-common-tools repo is expected to live. (When the environment variable is unset, repositories clone the repo just-in-time, which was the previous behavior.)