### PR TITLE
build: include jq in node release image

### DIFF
--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -70,7 +70,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     echo 'eval "$(pyenv init -)"' >> ~/.profile && \
     echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.profile
 
-ENV PATH="/home/node/.pyenv/bin:/home/node/.pyenv/shims:${PATH}"
+ENV PATH="/home/node/.pyenv/bin:/home/node/.pyenv/shims:/home/node/.npm-global/bin:${PATH}"
 
 # Install python
 RUN pyenv install 3.12.10 && \

--- a/node/18-user/Dockerfile
+++ b/node/18-user/Dockerfile
@@ -25,6 +25,9 @@ RUN set -ex; \
     gnupg-agent \
     lsb-release \
     software-properties-common \
+    git \
+    jq \
+    zip \
     ; \
   rm -rf /var/lib/apt/lists/*
 

--- a/node/cloudbuild-test.yaml
+++ b/node/cloudbuild-test.yaml
@@ -16,13 +16,21 @@ timeout: 7200s  # 2 hours
 steps:
 
 # Node 18
-- name: gcr.io/cloud-builders/docker
+- id: build-18
+  name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:18-user', '.']
   dir: 'node/18-user'
   waitFor: ['-']
 
 # Node 18
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:18-user', '.']
+- id: build-18-puppeteer
+  name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:18-puppeteer', '.']
   dir: 'node/18-puppeteer'
   waitFor: ['-']
+
+- name: gcr.io/gcp-runtimes/structure_test
+  args:
+    ["-i", "gcr.io/cloud-devrel-kokoro-resources/node:18-user", "--config", "node/node18.yaml", "-v"]
+  waitFor: ["build-18"]
+  

--- a/node/cloudbuild-test.yaml
+++ b/node/cloudbuild-test.yaml
@@ -31,6 +31,5 @@ steps:
 
 - name: gcr.io/gcp-runtimes/structure_test
   args:
-    ["-i", "gcr.io/cloud-devrel-kokoro-resources/node:18-user", "--config", "node/node18.yaml", "-v"]
+    ["-i", "gcr.io/cloud-devrel-kokoro-resources/node:18-user", "--config", "/workspace/node/node18.yaml", "-v"]
   waitFor: ["build-18"]
-  

--- a/node/node18.yaml
+++ b/node/node18.yaml
@@ -16,10 +16,10 @@ schemaVersion: 1.0.0
 commandTests:
 - name: "node"
   command: ["node", "--version"]
-  expectedOutput: ["npm@10.7.0"]
+  expectedOutput: ["v18.*"]
 - name: "npm"
   command: ["npm", "--version"]
-  expectedOutput: ["npm@10.7.0"]
+  expectedOutput: ["10.*"]
 - name: "gcloud"
   command: ["gcloud", "version"]
   expectedOutput: ["Google Cloud SDK"]

--- a/node/node18.yaml
+++ b/node/node18.yaml
@@ -1,0 +1,40 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+schemaVersion: 1.0.0
+commandTests:
+- name: "node"
+  command: ["node", "--version"]
+  expectedOutput: ["npm@10.7.0"]
+- name: "npm"
+  command: ["npm", "--version"]
+  expectedOutput: ["npm@10.7.0"]
+- name: "gcloud"
+  command: ["gcloud", "version"]
+  expectedOutput: ["Google Cloud SDK"]
+- name: "python"
+  command: ["python", "--version"]
+  expectedOutput: ["Python 3.12.10"]
+- name: "docker"
+  command: ["docker", "--version"]
+  expectedOutput: ["Docker version *"]
+- name: "jq"
+  command: ["jq", "--version"]
+  expectedOutput: ["jq-"]
+- name: "git"
+  command: ["git", "--version"]
+  expectedOutput: ["git version"]
+- name: "zip"
+  command: ["zip", "--version"]
+  expectedOutput: ["This is Zip"]


### PR DESCRIPTION
Most other release containers include the `jq` CLI to handle json parsing

This also adds a test to ensure the container contains the expected build tools