### PR TITLE
fix: remove bundled setuptools in python-multi

### DIFF
--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -131,8 +131,9 @@ RUN for PYTHON_VERSION in 3.7.17 3.8.20 3.9.23 3.10.18 3.11.13 3.12.11 3.13.5; d
     && rm -r python-${PYTHON_VERSION}.tar.xz.asc \
     && mkdir -p /usr/src/python-${PYTHON_VERSION} \
     && tar -xJC /usr/src/python-${PYTHON_VERSION} --strip-components=1 -f python-${PYTHON_VERSION}.tar.xz \
-    # Remove all bundled setuptools wheels
-    # since there is no fix for CVE-2025-47273/CVE-2025-47273.
+    # TODO: Remove this code once all Python verions include bundled setuptools 79.0.1 or newer.
+    # In the interim, remove all bundled setuptools wheels
+    # since there is no release for CVE-2025-47273/CVE-2025-47273 in Python 3.8, 3.9, 3.10, 3.11, 3.12.
     # See https://github.com/python/cpython/issues/135374#issuecomment-2963361124
     && rm -rf /usr/src/python-${PYTHON_VERSION}/Lib/ensurepip/_bundled/setuptools*.whl \
     && rm python-${PYTHON_VERSION}.tar.xz \
@@ -149,7 +150,8 @@ RUN for PYTHON_VERSION in 3.7.17 3.8.20 3.9.23 3.10.18 3.11.13 3.12.11 3.13.5; d
   && rm -rf ~/.cache/ \
   && rm -r "$GNUPGHOME"
 
-# Remove bundled setuptools 67.6.1 wheel
+# TODO: Remove this code once the next patch version of Python 3.12 runtime is released
+# In the interim, remove bundled setuptools 67.6.1 wheel
 # since it does not include a fix for CVE-2025-47273/CVE-2025-47273.
 # As per https://github.com/python/cpython/issues/135374#issuecomment-2963361124,
 # this test file is not needed at runtime.
@@ -227,7 +229,9 @@ RUN python3.12 -m venv /venv
 RUN /venv/bin/python -m pip install --no-cache-dir -r /requirements.txt
 ENV PATH /venv/bin:$PATH
 
-# Remove bundled setuptools 75.3.2 wheel
+# TODO: Remove this code once there is a newer version of virtualenv which does not include setuptools 75.3.2
+# https://github.com/pypa/virtualenv/tree/main/src/virtualenv/seed/wheels/embed
+# In the interim, remove the bundled setuptools 75.3.2 wheel
 # since it does not include a fix for CVE-2025-47273/CVE-2025-47273.
 RUN rm -rf /venv/lib/python3.12/site-packages/virtualenv/seed/wheels/embed/setuptools-75.3.2-py3-none-any.whl
 

--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -131,6 +131,10 @@ RUN for PYTHON_VERSION in 3.7.17 3.8.20 3.9.23 3.10.18 3.11.13 3.12.11 3.13.5; d
     && rm -r python-${PYTHON_VERSION}.tar.xz.asc \
     && mkdir -p /usr/src/python-${PYTHON_VERSION} \
     && tar -xJC /usr/src/python-${PYTHON_VERSION} --strip-components=1 -f python-${PYTHON_VERSION}.tar.xz \
+    # Remove all bundled setuptools wheels
+    # since there is no fix for CVE-2025-47273/CVE-2025-47273.
+    # See https://github.com/python/cpython/issues/135374#issuecomment-2963361124
+    && rm -rf /usr/src/python-${PYTHON_VERSION}/Lib/ensurepip/_bundled/setuptools*.whl \
     && rm python-${PYTHON_VERSION}.tar.xz \
     && cd /usr/src/python-${PYTHON_VERSION} \
     && ./configure \
@@ -144,6 +148,12 @@ RUN for PYTHON_VERSION in 3.7.17 3.8.20 3.9.23 3.10.18 3.11.13 3.12.11 3.13.5; d
   && rm -rf /usr/src/python* \
   && rm -rf ~/.cache/ \
   && rm -r "$GNUPGHOME"
+
+# Remove bundled setuptools 67.6.1 wheel
+# since it does not include a fix for CVE-2025-47273/CVE-2025-47273.
+# As per https://github.com/python/cpython/issues/135374#issuecomment-2963361124,
+# this test file is not needed at runtime.
+RUN rm -rf /usr/local/lib/python3.12/test/wheeldata/setuptools-67.6.1-py3-none-any.whl
 
 # Install pip on Python 3.10 only.
 # If the environment variable is called "PIP_VERSION", pip explodes with
@@ -205,11 +215,21 @@ RUN for PYTHON_VERSION in 3.9 3.10 3.11; do \
     --no-cache-dir \
     --require-hashes \
     -r /requirements.txt \
+    # Remove bundled setuptools 75.3.2 wheel
+    # since it does not include a fix for CVE-2025-47273/CVE-2025-47273.
+    && rm -rf /usr/local/lib/python${PYTHON_VERSION}/site-packages/virtualenv/seed/wheels/embed/setuptools-75.3.2-py3-none-any.whl \
   ; done
 
-RUN python3.10 -m venv /venv
+# Python 3.12 is preferred because it does not include
+# a bundled version of setuptools in `Lib/ensurepip/_bundled`
+# which could be impacted by CVE-2025-47273/CVE-2025-47273.
+RUN python3.12 -m venv /venv
 RUN /venv/bin/python -m pip install --no-cache-dir -r /requirements.txt
 ENV PATH /venv/bin:$PATH
+
+# Remove bundled setuptools 75.3.2 wheel
+# since it does not include a fix for CVE-2025-47273/CVE-2025-47273.
+RUN rm -rf /venv/lib/python3.12/site-packages/virtualenv/seed/wheels/embed/setuptools-75.3.2-py3-none-any.whl
 
 # Setup Cloud SDK
 ENV CLOUD_SDK_VERSION 528.0.0


### PR DESCRIPTION
https://github.com/googleapis/testing-infra-docker/pull/490 upgraded setuptools in `python-multi` to version `79.0.1`, however there were still older bundled versions of setuptools installed.

See reproduction below

```
partheniou@partheniou-vm-3:~$ docker run --rm -it --entrypoint /bin/bash gcr.io/cloud-devrel-public-resources/python-multi:latest
root@8d86a2a381c9:/#  find / -name "setuptools*"
/usr/local/lib/python3.11/site-packages/virtualenv/seed/wheels/embed/setuptools-75.3.2-py3-none-any.whl
/usr/local/lib/python3.11/site-packages/virtualenv/seed/wheels/embed/setuptools-80.3.1-py3-none-any.whl
/usr/local/lib/python3.11/site-packages/setuptools-79.0.1.dist-info
/usr/local/lib/python3.11/site-packages/setuptools
/usr/local/lib/python3.11/site-packages/setuptools/config/setuptools.schema.json
/usr/local/lib/python3.11/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-311.pyc
/usr/local/lib/python3.11/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl
/usr/local/lib/python3.9/site-packages/virtualenv/seed/wheels/embed/setuptools-75.3.2-py3-none-any.whl
/usr/local/lib/python3.9/site-packages/virtualenv/seed/wheels/embed/setuptools-80.3.1-py3-none-any.whl
/usr/local/lib/python3.9/site-packages/setuptools-79.0.1.dist-info
/usr/local/lib/python3.9/site-packages/setuptools
/usr/local/lib/python3.9/site-packages/setuptools/config/setuptools.schema.json
/usr/local/lib/python3.9/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-39.pyc
/usr/local/lib/python3.9/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.9/ensurepip/_bundled/setuptools-58.1.0-py3-none-any.whl
/usr/local/lib/python3.10/site-packages/virtualenv/seed/wheels/embed/setuptools-75.3.2-py3-none-any.whl
/usr/local/lib/python3.10/site-packages/virtualenv/seed/wheels/embed/setuptools-80.3.1-py3-none-any.whl
/usr/local/lib/python3.10/site-packages/setuptools-79.0.1.dist-info
/usr/local/lib/python3.10/site-packages/setuptools
/usr/local/lib/python3.10/site-packages/setuptools/config/setuptools.schema.json
/usr/local/lib/python3.10/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-310.pyc
/usr/local/lib/python3.10/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.10/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl
/usr/local/lib/python3.8/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-38.pyc
/usr/local/lib/python3.8/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.8/ensurepip/_bundled/setuptools-56.0.0-py3-none-any.whl
/usr/local/lib/python3.7/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-37.pyc
/usr/local/lib/python3.7/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.7/ensurepip/_bundled/setuptools-47.1.0-py3-none-any.whl
/usr/local/lib/python3.13/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-313.pyc
/usr/local/lib/python3.13/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.13/test/wheeldata/setuptools-79.0.1-py3-none-any.whl
/usr/local/lib/python3.12/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-312.pyc
/usr/local/lib/python3.12/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.12/test/wheeldata/setuptools-67.6.1-py3-none-any.whl
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/cffi/setuptools_ext.py
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/pip/_internal/utils/setuptools_build.py
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/setuptools-79.0.1.dist-info
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/setuptools
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/setuptools/config/setuptools.schema.json
/venv/lib/python3.10/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-310.pyc
/venv/lib/python3.10/site-packages/pip/_internal/utils/setuptools_build.py
/venv/lib/python3.10/site-packages/setuptools
/venv/lib/python3.10/site-packages/setuptools/config/setuptools.schema.json
/venv/lib/python3.10/site-packages/virtualenv/seed/wheels/embed/setuptools-75.3.2-py3-none-any.whl
/venv/lib/python3.10/site-packages/virtualenv/seed/wheels/embed/setuptools-80.3.1-py3-none-any.whl
/venv/lib/python3.10/site-packages/setuptools-79.0.1.dist-info
```

With the changes in this PR, the older wheel files are no longer included

 ```
partheniou@partheniou-vm-3:~$ docker run --rm -it --entrypoint /bin/bash test_multi
root@cf7e51b9adeb:/#  find / -name "setuptools*"
/usr/local/lib/python3.11/site-packages/virtualenv/seed/wheels/embed/setuptools-80.3.1-py3-none-any.whl
/usr/local/lib/python3.11/site-packages/setuptools-79.0.1.dist-info
/usr/local/lib/python3.11/site-packages/setuptools
/usr/local/lib/python3.11/site-packages/setuptools/config/setuptools.schema.json
/usr/local/lib/python3.11/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-311.pyc
/usr/local/lib/python3.11/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.9/site-packages/virtualenv/seed/wheels/embed/setuptools-80.3.1-py3-none-any.whl
/usr/local/lib/python3.9/site-packages/setuptools-79.0.1.dist-info
/usr/local/lib/python3.9/site-packages/setuptools
/usr/local/lib/python3.9/site-packages/setuptools/config/setuptools.schema.json
/usr/local/lib/python3.9/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-39.pyc
/usr/local/lib/python3.9/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.10/site-packages/virtualenv/seed/wheels/embed/setuptools-80.3.1-py3-none-any.whl
/usr/local/lib/python3.10/site-packages/setuptools-79.0.1.dist-info
/usr/local/lib/python3.10/site-packages/setuptools
/usr/local/lib/python3.10/site-packages/setuptools/config/setuptools.schema.json
/usr/local/lib/python3.10/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-310.pyc
/usr/local/lib/python3.10/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.8/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-38.pyc
/usr/local/lib/python3.8/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.7/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-37.pyc
/usr/local/lib/python3.7/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.13/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-313.pyc
/usr/local/lib/python3.13/site-packages/pip/_internal/utils/setuptools_build.py
/usr/local/lib/python3.13/test/wheeldata/setuptools-79.0.1-py3-none-any.whl
/usr/local/lib/python3.12/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-312.pyc
/usr/local/lib/python3.12/site-packages/pip/_internal/utils/setuptools_build.py
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/cffi/setuptools_ext.py
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/pip/_internal/utils/setuptools_build.py
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/setuptools-79.0.1.dist-info
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/setuptools
/google-cloud-sdk/platform/bundledpythonunix/lib/python3.12/site-packages/setuptools/config/setuptools.schema.json
/venv/lib/python3.12/site-packages/pip/_internal/utils/__pycache__/setuptools_build.cpython-312.pyc
/venv/lib/python3.12/site-packages/pip/_internal/utils/setuptools_build.py
/venv/lib/python3.12/site-packages/virtualenv/seed/wheels/embed/setuptools-80.3.1-py3-none-any.whl
/venv/lib/python3.12/site-packages/setuptools-79.0.1.dist-info
/venv/lib/python3.12/site-packages/setuptools
/venv/lib/python3.12/site-packages/setuptools/config/setuptools.schema.json
```