### PR TITLE
chore(python): adds libgdal-dev and dependencies

### DIFF
--- a/python/googleapis/python-multi/Dockerfile
+++ b/python/googleapis/python-multi/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
     curl \
     dirmngr \
     enchant-2 \
+    gdal-bin \
     git \
     gpg-agent \
     graphviz \
@@ -47,7 +48,9 @@ RUN apt-get update \
     libenchant-2-2 \
     libexpat1-dev \
     libffi-dev \
+    libgdal-dev \
     liblzma-dev \
+    libpq-dev \
     libreadline-dev \
     libsnappy-dev \
     libssl-dev \


### PR DESCRIPTION
Looking into one of the continuous CI/CD failures for the `python-bigquery` library: 

The virtual environment install fails for Python 3.14 because `python-multi` does not have the file `gdal-config`.

I recommend that we install `libgdal-dev` (and the necessary dependencies: `libpq-dev`, `gdal-bin`) via edits in the `python-multi` DockerFile.

```
Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [40 lines of output]
      Traceback (most recent call last):
        File "/tmpfs/src/github/python-bigquery/.nox/unit-3-14/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in 
          main()
          ~~~~^^
        File "/tmpfs/src/github/python-bigquery/.nox/unit-3-14/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmpfs/src/github/python-bigquery/.nox/unit-3-14/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 175, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/tmp/pip-build-env-rii9y6xt/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 374, in prepare_metadata_for_build_wheel
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/tmp/pip-build-env-rii9y6xt/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "", line 154, in 
        File "", line 129, in get_gdal_config
        File "", line 85, in get_gdal_config
        File "", line 39, in read_response
        File "/usr/local/lib/python3.14/subprocess.py", line 472, in check_output
          return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
                 ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     **kwargs).stdout
                     ^^^^^^^^^
        File "/usr/local/lib/python3.14/subprocess.py", line 554, in run
          with Popen(*popenargs, **kwargs) as process:
               ~~~~~^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/subprocess.py", line 1038, in __init__
          self._execute_child(args, executable, preexec_fn, close_fds,
          ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              pass_fds, cwd, env,
                              ^^^^^^^^^^^^^^^^^^^
          ...<5 lines>...
                              gid, gids, uid, umask,
                              ^^^^^^^^^^^^^^^^^^^^^^
                              start_new_session, process_group)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.14/subprocess.py", line 1970, in _execute_child
          raise child_exception_type(errno_num, err_msg, err_filename)
      FileNotFoundError: [Errno 2] No such file or directory: 'gdal-config'
      [end of output]
```