### PR TITLE
ci: annotate python-multi image in cloud-devrel-kokoro-resources as test

### DIFF
--- a/python/cloudbuild.yaml
+++ b/python/cloudbuild.yaml
@@ -34,6 +34,11 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python-multi', 'gcr.io/cloud-devrel-public-resources/python-multi']
   waitFor: ['python-multi']
+- name: gcr.io/cloud-builders/docker
+  # The python-multi image in cloud-devrel-kokoro-resources is for
+  # running integration tests, not for release builds.
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python', 'gcr.io/cloud-devrel-kokoro-resources/python:infrastructure-public-image-$SHORT_SHA']
+  waitFor: ['python-multi']
 
 # cloud-devrel-kokoro-resources/python
 - name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
The python-multi image hosted in cloud-devrel-kokoro-resources are used
for test infrastructure. This is not used for releases.

Background: go/sdk-platform:nonpublic-containers
