### PR TITLE
build(python,ruby): fix tagging

### DIFF
--- a/python/cloudbuild.yaml
+++ b/python/cloudbuild.yaml
@@ -22,7 +22,10 @@ steps:
   waitFor: ['-']
   id: 'python-base'
 - name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python-base', 'gcr.io/cloud-devrel-public-resources/python-base', 'gcr.io/cloud-devrel-public-resources/python-base:infrastructure-public-image-$COMMIT_SHA']
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python-base', 'gcr.io/cloud-devrel-public-resources/python-base']
+  waitFor: ['python-base']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python-base', 'gcr.io/cloud-devrel-public-resources/python-base:infrastructure-public-image-$COMMIT_SHA']
   waitFor: ['python-base']
 
 # googleapis/python-multi
@@ -32,7 +35,10 @@ steps:
   id: 'python-multi'
   waitFor: ['-']
 - name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python-multi', 'gcr.io/cloud-devrel-public-resources/python-multi', 'gcr.io/cloud-devrel-public-resources/python-multi:infrastructure-public-image-$COMMIT_SHA']
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python-multi', 'gcr.io/cloud-devrel-public-resources/python-multi']
+  waitFor: ['python-multi']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python-multi', 'gcr.io/cloud-devrel-public-resources/python-multi:infrastructure-public-image-$COMMIT_SHA']
   waitFor: ['python-multi']
 
 # cloud-devrel-kokoro-resources/python
@@ -42,7 +48,10 @@ steps:
   waitFor: ['python-base']
   id: 'python'
 - name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python', 'gcr.io/cloud-devrel-public-resources/python', 'gcr.io/cloud-devrel-public-resources/python:infrastructure-public-image-$COMMIT_SHA']
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python', 'gcr.io/cloud-devrel-public-resources/python']
+  waitFor: ['python']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/python', 'gcr.io/cloud-devrel-public-resources/python:infrastructure-public-image-$COMMIT_SHA']
   waitFor: ['python']
 
 options:

--- a/ruby/cloudbuild.yaml
+++ b/ruby/cloudbuild.yaml
@@ -45,7 +45,10 @@ steps:
   waitFor: ['build-multi']
 - name: gcr.io/cloud-builders/docker
   args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi',
-                'gcr.io/cloud-devrel-public-resources/yoshi-ruby/multi',
+                'gcr.io/cloud-devrel-public-resources/yoshi-ruby/multi']
+  waitFor: ['build-multi']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi',
                 'gcr.io/cloud-devrel-public-resources/yoshi-ruby/multi:infrastructure-public-image-$COMMIT_SHA']
   waitFor: ['build-multi']
 


### PR DESCRIPTION
Split `docker tag` commands -- you can only do one additional tag this way.

`docker build` supports multiple `-t <tag-name>` arguments, but `docker tag` only supports 2 positional arguments