### PR TITLE
chore: mark all images in this repo as infra

### DIFF
--- a/common/cloudbuild-airlock.yaml
+++ b/common/cloudbuild-airlock.yaml
@@ -31,7 +31,8 @@ steps:
   # https://docs.docker.com/build/builders/drivers/#loading-to-local-image-store
   args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
     "--load",
-    "-t", "us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}", "."]
+    "-t", "us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}",
+    "-t", "us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}:infrastructure-public-image-$COMMIT_SHA", "."]
   dir: '${_IMAGE_SOURCE_PATH}'
   id: '${_IMAGE_NAME}'
   waitFor: ["buildx-create"]

--- a/common/cloudbuild-structure-test.yaml
+++ b/common/cloudbuild-structure-test.yaml
@@ -25,6 +25,8 @@ steps:
   args: [
     'build', '-t',
     'us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}',
+    '-t',
+    'us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}:infrastructure-public-image-$COMMIT_SHA',
     '.']
   dir: '${_IMAGE_SOURCE_PATH}'
   id: '${_IMAGE_NAME}'

--- a/common/cloudbuild.yaml
+++ b/common/cloudbuild.yaml
@@ -25,6 +25,8 @@ steps:
   args: [
     'build', '-t',
     'us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}',
+    '-t',
+    'us-central1-docker.pkg.dev/${_PROJECT_ID}/release-images-dev/${_IMAGE_NAME}:infrastructure-public-image-$COMMIT_SHA',
     '.']
   dir: '${_IMAGE_SOURCE_PATH}'
   id: '${_IMAGE_NAME}'

--- a/go/cloudbuild-release.yaml
+++ b/go/cloudbuild-release.yaml
@@ -19,7 +19,7 @@ timeout: 7200s # 2 hours
 steps:
     # Go 1.25 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go125", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go125", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go125:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go125-release
     id: go125-build
     waitFor: ["-"]
@@ -36,7 +36,7 @@ steps:
 
     # Go 1.26 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go126", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go126", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go126:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go126-release
     id: go126-build
     waitFor: ["-"]

--- a/go/cloudbuild-test.yaml
+++ b/go/cloudbuild-test.yaml
@@ -19,7 +19,7 @@ timeout: 7200s
 steps:
   # Go 1.24 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go124", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go124", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go124:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go124
     id: go124-build
     waitFor: ["-"]
@@ -36,7 +36,7 @@ steps:
 
   # Go 1.25 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go125", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go125", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go125:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go125
     id: go125-build
     waitFor: ["-"]
@@ -54,7 +54,7 @@ steps:
   
   # Go 1.26 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go126", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go126", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/go126:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go126
     id: go126-build
     waitFor: ["-"]
@@ -71,7 +71,7 @@ steps:
 
   # Go 1.25 release build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go125", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go125", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go125:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go125-release
     id: go125-release-build
     waitFor: ["-"]
@@ -88,7 +88,7 @@ steps:
 
   # Go 1.26 release build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go126", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go126", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/go126:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go126-release
     id: go126-release-build
     waitFor: ["-"]

--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -19,7 +19,7 @@ timeout: 7200s # 2 hours
 steps:
   # Go 1.24 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/go124", "."]
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/go124", "-t", "gcr.io/$PROJECT_ID/go124:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go124
     id: go124-build
     waitFor: ["-"]
@@ -36,7 +36,7 @@ steps:
 
     # Go 1.25 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/go125", "."]
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/go125", "-t", "gcr.io/$PROJECT_ID/go125:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go125
     id: go125-build
     waitFor: ["-"]
@@ -53,7 +53,7 @@ steps:
 
     # Go 1.26 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/go126", "."]
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/go126", "-t", "gcr.io/$PROJECT_ID/go126:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: go/go126
     id: go126-build
     waitFor: ["-"]

--- a/infrastructure/cloudbuild-test.yaml
+++ b/infrastructure/cloudbuild-test.yaml
@@ -24,6 +24,8 @@ steps:
       "--no-cache",
       "-t",
       "googleapis",
+      "-t",
+      "googleapis:infrastructure-public-image-$COMMIT_SHA",
       ".",
     ]
   dir: "infrastructure/googleapis"

--- a/infrastructure/cloudbuild.yaml
+++ b/infrastructure/cloudbuild.yaml
@@ -24,6 +24,8 @@ steps:
       "--no-cache",
       "-t",
       "gcr.io/$PROJECT_ID/googleapis",
+      "-t",
+      "gcr.io/$PROJECT_ID/googleapis:infrastructure-public-image-$COMMIT_SHA",
       ".",
     ]
   dir: "infrastructure/googleapis"

--- a/java/cloudbuild-release.yaml
+++ b/java/cloudbuild-release.yaml
@@ -32,7 +32,8 @@ steps:
     # https://docs.docker.com/build/builders/drivers/#loading-to-local-image-store
     args: ["buildx", "build", "--add-host=metadata.google.internal:169.254.169.254",
       "--load",
-      "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8-airlock", "."]
+      "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8-airlock",
+      "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8-airlock:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: java/java8-airlock
     id: java8-airlock-build
     waitFor: ["buildx-create"]
@@ -42,7 +43,7 @@ steps:
     waitFor: ["java8-airlock-build"]
   # Java 8 build
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java8:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: java/java8
     id: java8-build
     waitFor: ["-"]
@@ -53,7 +54,7 @@ steps:
 
   # Java 17 build specifically for java-storage
   - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java17", "."]
+    args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java17", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/release-images/java17:infrastructure-public-image-$COMMIT_SHA", "."]
     dir: java/java17
     id: java17-build
     # Without waiting Java 8, you would get a conflict error "daemon: Conflict. The container name "/buildx_buildkit_buildx-builder0" is already in use by container"

--- a/java/cloudbuild-test.yaml
+++ b/java/cloudbuild-test.yaml
@@ -79,6 +79,14 @@ steps:
               "gcr.io/cloud-devrel-public-resources/java11014",
       ]
     waitFor: ["java11014-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+              "tag",
+              "gcr.io/$PROJECT_ID/java11014",
+              "gcr.io/cloud-devrel-public-resources/java11014:infrastructure-public-image-$COMMIT_SHA",
+      ]
+    waitFor: ["java11014-build"]
 
   # Java 17 build
   - name: gcr.io/cloud-builders/docker
@@ -97,5 +105,13 @@ steps:
               "tag",
               "gcr.io/$PROJECT_ID/java17",
               "gcr.io/cloud-devrel-public-resources/java17",
+      ]
+    waitFor: ["java17-build"]
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+              "tag",
+              "gcr.io/$PROJECT_ID/java17",
+              "gcr.io/cloud-devrel-public-resources/java17:infrastructure-public-image-$COMMIT_SHA",
       ]
     waitFor: ["java17-build"]

--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
       [
         "tag",
         "gcr.io/$PROJECT_ID/java8",
-        "gcr.io/cloud-devrel-public-resources/java8:infrastructure-public-image-$SHORT_SHA",
+        "gcr.io/cloud-devrel-public-resources/java8:infrastructure-public-image-$COMMIT_SHA",
       ]
     waitFor: ["java8-build"]
 
@@ -67,7 +67,7 @@ steps:
       [
         "tag",
         "gcr.io/$PROJECT_ID/java11014",
-        "gcr.io/cloud-devrel-public-resources/java11014:infrastructure-public-image-$SHORT_SHA",
+        "gcr.io/cloud-devrel-public-resources/java11014:infrastructure-public-image-$COMMIT_SHA",
       ]
     waitFor: ["java11014-build"]
 
@@ -94,7 +94,7 @@ steps:
       [
         "tag",
         "gcr.io/$PROJECT_ID/java17",
-        "gcr.io/cloud-devrel-public-resources/java17:infrastructure-public-image-$SHORT_SHA",
+        "gcr.io/cloud-devrel-public-resources/java17:infrastructure-public-image-$COMMIT_SHA",
       ]
     waitFor: ["java17-build"]
     # Java 21 build
@@ -120,7 +120,7 @@ steps:
       [
         "tag",
         "gcr.io/$PROJECT_ID/java21",
-        "gcr.io/cloud-devrel-public-resources/java21:infrastructure-public-image-$SHORT_SHA",
+        "gcr.io/cloud-devrel-public-resources/java21:infrastructure-public-image-$COMMIT_SHA",
       ]
     waitFor: ["java21-build"]
 images:

--- a/node/cloudbuild-release.yaml
+++ b/node/cloudbuild-release.yaml
@@ -17,17 +17,17 @@ steps:
 
 # Node 18
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node18', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node18', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node18:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'node/18-user'
   waitFor: ['-']
 # Node 18 puppeteer
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node18-puppeteer', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node18-puppeteer', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node18-puppeteer:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'node/18-puppeteer'
   waitFor: ['-']
 # Node 22 user
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node22', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node22', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/node22:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'node/22-user'
   waitFor: ['-']
 

--- a/node/cloudbuild.yaml
+++ b/node/cloudbuild.yaml
@@ -17,17 +17,17 @@ steps:
 
 # Node 18
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:18-user', '-t', 'gcr.io/cloud-devrel-public-resources/node:18-user', '.']
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:18-user', '-t', 'gcr.io/cloud-devrel-public-resources/node:18-user', '-t', 'gcr.io/cloud-devrel-public-resources/node:18-user-infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'node/18-user'
   waitFor: ['-']
 # Node 18
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:18-puppeteer', '-t', 'gcr.io/cloud-devrel-public-resources/node:18-puppeteer', '.']
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:18-puppeteer', '-t', 'gcr.io/cloud-devrel-public-resources/node:18-puppeteer', '-t', 'gcr.io/cloud-devrel-public-resources/node:18-puppeteer-infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'node/18-puppeteer'
   waitFor: ['-']
 # Node 22
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:22-user', '-t', 'gcr.io/cloud-devrel-public-resources/node:22-user', '.']
+  args: ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/node:22-user', '-t', 'gcr.io/cloud-devrel-public-resources/node:22-user', '-t', 'gcr.io/cloud-devrel-public-resources/node:22-user-infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'node/22-user'
   waitFor: ['-']
 

--- a/php/cloudbuild-release.yaml
+++ b/php/cloudbuild-release.yaml
@@ -24,7 +24,7 @@ steps:
 - id: 'build-php81'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php81', '.']
+    ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php81', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php81:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/php81'
   waitFor: ['-']
 
@@ -38,7 +38,7 @@ steps:
 - id: 'build-release'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php-release', '.']
+    ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php-release', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/php-release:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/release'
   waitFor: ['-']
 - name: gcr.io/gcp-runtimes/structure_test

--- a/php/cloudbuild-test.yaml
+++ b/php/cloudbuild-test.yaml
@@ -23,7 +23,7 @@ steps:
 - id: 'build-php81'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php81', '-t', 'gcr.io/cloud-devrel-public-resources/php81', '.']
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php81', '-t', 'gcr.io/cloud-devrel-public-resources/php81', '-t', 'gcr.io/cloud-devrel-public-resources/php81:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/php81'
   waitFor: ['-']
 
@@ -36,7 +36,7 @@ steps:
 - id: 'build-php82'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php82', '-t', 'gcr.io/cloud-devrel-public-resources/php82', '.']
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php82', '-t', 'gcr.io/cloud-devrel-public-resources/php82', '-t', 'gcr.io/cloud-devrel-public-resources/php82:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/php82'
   waitFor: ['-']
 
@@ -49,7 +49,7 @@ steps:
 - id: 'build-php83'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php83', '-t', 'gcr.io/cloud-devrel-public-resources/php83', '.']
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php83', '-t', 'gcr.io/cloud-devrel-public-resources/php83', '-t', 'gcr.io/cloud-devrel-public-resources/php83:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/php83'
   waitFor: ['-']
 
@@ -62,7 +62,7 @@ steps:
 - id: 'build-php-release'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/release', '-t', 'gcr.io/cloud-devrel-public-resources/release', '.']
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/release', '-t', 'gcr.io/cloud-devrel-public-resources/release', '-t', 'gcr.io/cloud-devrel-public-resources/release:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/release'
   waitFor: ['-']
 

--- a/php/cloudbuild.yaml
+++ b/php/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
 - id: 'build-php81'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php81', '-t', 'gcr.io/cloud-devrel-public-resources/php81', '.']
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php81', '-t', 'gcr.io/cloud-devrel-public-resources/php81', '-t', 'gcr.io/cloud-devrel-public-resources/php81:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/php81'
   waitFor: ['-']
 
@@ -37,7 +37,7 @@ steps:
 - id: 'build-php82'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php82', '-t', 'gcr.io/cloud-devrel-public-resources/php82', '.']
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php82', '-t', 'gcr.io/cloud-devrel-public-resources/php82', '-t', 'gcr.io/cloud-devrel-public-resources/php82:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/php82'
   waitFor: ['-']
 
@@ -50,7 +50,7 @@ steps:
 - id: 'build-php83'
   name: gcr.io/cloud-builders/docker
   args:
-    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php83', '-t', 'gcr.io/cloud-devrel-public-resources/php83', '.']
+    ['build', '-t', 'gcr.io/cloud-devrel-kokoro-resources/php83', '-t', 'gcr.io/cloud-devrel-public-resources/php83', '-t', 'gcr.io/cloud-devrel-public-resources/php83:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'php/php83'
   waitFor: ['-']
 

--- a/python/cloudbuild-release.yaml
+++ b/python/cloudbuild-release.yaml
@@ -16,7 +16,7 @@ timeout: 7200s  # 2 hours
 steps:
 # googleapis/python-multi
 - name: gcr.io/cloud-builders/docker
-  args: ['build',  '--cache-from', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/python-multi', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/python-multi', '.']
+  args: ['build',  '--cache-from', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/python-multi', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/python-multi', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/python-multi:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'python/googleapis/python-multi'
   id: 'python-multi'
   waitFor: ['-']

--- a/python/cloudbuild-test.yaml
+++ b/python/cloudbuild-test.yaml
@@ -17,21 +17,21 @@ steps:
 
 # cloud-devrel-kokoro-resources/python-base
 - name: gcr.io/cloud-builders/docker
-  args: ['build',  '--cache-from', 'gcr.io/cloud-devrel-kokoro-resources/python-base', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python-base', '.']
+  args: ['build',  '--cache-from', 'gcr.io/cloud-devrel-kokoro-resources/python-base', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python-base', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python-base:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'python/cloud-devrel-kokoro-resources/python-base'
   waitFor: ['-']
   id: 'python-base'
 
 # googleapis/python-multi
 - name: gcr.io/cloud-builders/docker
-  args: ['build',  '--cache-from', 'gcr.io/cloud-devrel-kokoro-resources/python-multi', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python-multi', '.']
+  args: ['build',  '--cache-from', 'gcr.io/cloud-devrel-kokoro-resources/python-multi', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python-multi', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python-multi:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'python/googleapis/python-multi'
   id: 'python-multi'
   waitFor: ['-']
 
 # cloud-devrel-kokoro-resources/python
 - name: gcr.io/cloud-builders/docker
-  args: ['build',  '--no-cache', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python', '.']
+  args: ['build',  '--no-cache', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python', '-t', 'gcr.io/cloud-devrel-kokoro-resources/python:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'python/cloud-devrel-kokoro-resources/python'
   waitFor: ['python-base']
   id: 'python'

--- a/ruby/cloudbuild-release.yaml
+++ b/ruby/cloudbuild-release.yaml
@@ -18,14 +18,14 @@ steps:
 # Build Ruby multi-use image (used for integration tests)
 - id: 'build-multi'
   name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-multi', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-multi', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-multi:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'ruby/multi'
   waitFor: ['-']
 
 # Build Ruby release image
 - id: 'build-release'
   name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-release', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-release', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/ruby-release:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'ruby/release'
   waitFor: ['-']
 

--- a/ruby/cloudbuild-test.yaml
+++ b/ruby/cloudbuild-test.yaml
@@ -34,6 +34,8 @@ steps:
     - 'gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-release'
     - '-t'
     - 'gcr.io/cloud-devrel-public-resources/yoshi-ruby/multi'
+    - '-t'
+    - 'gcr.io/cloud-devrel-public-resources/yoshi-ruby/multi:infrastructure-public-image-$COMMIT_SHA'
     - '.'
   dir: 'ruby/multi'
   waitFor: ['-']

--- a/syft/cloudbuild-release.yaml
+++ b/syft/cloudbuild-release.yaml
@@ -18,7 +18,7 @@ steps:
 # Build Ruby multi-use image
 - id: 'build'
   name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'syft'
   waitFor: ['-']
 

--- a/syft/cloudbuild-test.yaml
+++ b/syft/cloudbuild-test.yaml
@@ -18,7 +18,7 @@ steps:
 # Build Ruby multi-use image
 - id: 'build'
   name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft', '.']
+  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/release-images/syft:infrastructure-public-image-$COMMIT_SHA', '.']
   dir: 'syft'
   waitFor: ['-']
 - name: gcr.io/gcp-runtimes/structure_test


### PR DESCRIPTION
All of the images in this repo are used for testing and release infra and although they are public are not intended to be used by end users. This is a documented tag for such use-cases.