### PR TITLE
chore: automate prod image tagging for googleapis image

### DIFF
--- a/infrastructure/cloudbuild.yaml
+++ b/infrastructure/cloudbuild.yaml
@@ -23,7 +23,9 @@ steps:
       "build",
       "--no-cache",
       "-t",
-      "gcr.io/$PROJECT_ID/googleapis",
+      "gcr.io/$PROJECT_ID/googleapis:latest",
+      "-t",
+      "gcr.io/$PROJECT_ID/googleapis:prod",
       ".",
     ]
   dir: "infrastructure/googleapis"
@@ -57,4 +59,5 @@ artifacts:
       - /workspace/output/*.tar.gz
 
 images:
-  - gcr.io/$PROJECT_ID/googleapis
+  - gcr.io/$PROJECT_ID/googleapis:latest
+  - gcr.io/$PROJECT_ID/googleapis:prod


### PR DESCRIPTION
Add the `prod` tag to the `googleapis` image build and push steps in `infrastructure/cloudbuild.yaml`. This ensures that when the image is successfully built and tested, the `prod` tag is automatically updated to point to the new image, removing the need for manual tagging.

Internal Bug: b/535200036